### PR TITLE
🎨 Palette: Improve accessibility and interaction of icon links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve accessibility of icon-only links
+**Learning:** In Astro components that loop over JSON data to create social grids or link lists, icon-only `<a>` elements frequently lack `aria-label` attributes, making them inaccessible to screen readers. Furthermore, the accompanying decorative `<img>` tags often lack empty `alt` and `aria-hidden="true"` attributes, causing redundant or confusing announcements.
+**Action:** Always add dynamic `aria-label` attributes based on the data item's name or icon, and explicitly hide decorative images from assistive technologies.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,21 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li>
+			<img
+				src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`}
+				alt=""
+				aria-hidden="true"
+			/>
+			<a
+				href={item.url}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-link"
+			>
+				{item.title}
+			</a>
+		</li>
 	))}
 </ul>
 <style>
@@ -25,5 +39,22 @@ const { items } = Astro.props;
 		width: 16px;
 		height: 16px;
 		margin-right: 0.5em;
+	}
+
+	.text-link {
+		transition: color 0.2s ease-in-out;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	.text-link:hover,
+	.text-link:focus-visible {
+		color: #1a891a;
+	}
+
+	.text-link:focus-visible {
+		outline: 2px solid #1a891a;
+		outline-offset: 4px;
+		border-radius: 2px;
 	}
 </style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,21 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li>
+			<a
+				href={item.url}
+				aria-label={item.title || item.icon}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="social-link"
+			>
+				<img
+					src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`}
+					alt=""
+					aria-hidden="true"
+				/>
+			</a>
+		</li>
 	))}
 </ul>
 <style>
@@ -24,6 +38,21 @@ const { items } = Astro.props;
 	img {
 		width: 48px;
 		height: 48px;
+		transition: transform 0.2s ease-in-out;
+	}
 
+	.social-link {
+		display: inline-block;
+		border-radius: 50%;
+	}
+
+	.social-link:hover img,
+	.social-link:focus-visible img {
+		transform: scale(1.1);
+	}
+
+	.social-link:focus-visible {
+		outline: 2px solid #1a891a;
+		outline-offset: 4px;
 	}
 </style>


### PR DESCRIPTION
💡 **What:** 
- Added `aria-label` attributes to icon-only links in `SocialGrid.astro`.
- Hid decorative images from screen readers using `alt="" aria-hidden="true"` in both `SocialGrid.astro` and `LinkGrid.astro`.
- Set external links to open in a new tab securely (`target="_blank" rel="noopener noreferrer"`).
- Added visual CSS focus and hover styles for better interaction feedback.
- Logged a critical learning in `.Jules/palette.md`.

🎯 **Why:** 
Icon-only links without accessible names are invisible to screen readers, making navigation difficult for users relying on assistive technologies. Similarly, decorative images without empty `alt` attributes can cause redundant or confusing announcements. Adding clear focus states ensures the interface is easily navigable via keyboard. Opening external links in a new tab with security attributes protects users and provides a better experience.

♿ **Accessibility:** 
- **Screen Readers:** Icons are now properly labeled or hidden as appropriate.
- **Keyboard Navigation:** Added clear focus indicators.

---
*PR created automatically by Jules for task [4784501560888438346](https://jules.google.com/task/4784501560888438346) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for icon-only links with ARIA labels
  * Enhanced screen reader support through proper alt text handling for decorative images
  * Added keyboard focus styling for better navigation visibility
  * Updated external link security attributes

* **Documentation**
  * Added accessibility guidelines for icon-only links and images

<!-- end of auto-generated comment: release notes by coderabbit.ai -->