### PR TITLE
⚡ Bolt: Dynamic import for Statsig analytics to reduce bundle size

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-28 - Dynamic Imports for Analytics
+**Learning:** Loading analytics libraries synchronously in the head can block rendering and increase bundle size significantly.
+**Action:** Use dynamic imports `import(...)` for non-critical analytics libraries like Statsig to reduce the initial load time and bundle size.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,27 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Dynamically import Statsig to reduce initial bundle size and speed up page load
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin }
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                });
             }
         </script>
     </head>


### PR DESCRIPTION
**💡 What:** The optimization changes the static, top-level imports of Statsig analytics packages (`@statsig/js-client`, `@statsig/session-replay`, `@statsig/web-analytics`) into dynamic imports `import(...)` that are only executed if an analytics key is present. 

**🎯 Why:** The static imports force the browser to download and parse these sizable scripts in the initial bundle, blocking rendering and slowing down the initial page load time. Deferring the loading of these non-critical scripts ensures that the core UI loads first.

**📊 Impact:** Substantial reduction in the initial client bundle payload, specifically splitting out the `Layout.astro` logic into asynchronous chunks.

**🔬 Measurement:** Run `bun run build`. Notice that the main chunk size is drastically reduced because the analytics packages are code-split and loaded dynamically instead of being bundled with the primary script logic.

---
*PR created automatically by Jules for task [471738456006162669](https://jules.google.com/task/471738456006162669) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized how analytics libraries are loaded to reduce initial page bundle size and improve page load performance.

* **Documentation**
  * Added internal documentation of performance optimization findings and best practices for analytics integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->