### PR TITLE
🎨 Palette: Accessibility improvements for icon links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Icon Link Accessibility
+**Learning:** Icon-only links and decorative images in Astro components (`SocialGrid.astro`, `LinkGrid.astro`) were missing proper ARIA attributes, making them inaccessible to screen readers.
+**Action:** Added `aria-label` to the links, dynamically falling back to the icon name if a title wasn't available. Added `alt=""` and `aria-hidden="true"` to the decorative images to hide them from assistive technologies.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title || item.icon}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 What: Added `aria-label` to icon-only links in `SocialGrid.astro` and marked companion `<img>` icons in both `SocialGrid.astro` and `LinkGrid.astro` as decorative with `alt="" aria-hidden="true"`.
🎯 Why: Icon-only links and purely decorative images were missing proper ARIA attributes, making them inaccessible to screen readers. This ensures screen readers will read the link's purpose rather than trying to read an image file path or ignoring the link entirely.
♿ Accessibility: Improved WCAG compliance by ensuring all interactive elements have accessible names and decorative images are properly hidden.

---
*PR created automatically by Jules for task [3531121733823562177](https://jules.google.com/task/3531121733823562177) started by @jgeofil*