### PR TITLE
🎨 Palette: Enhance accessibility of icon-only links and decorative images

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Accessible Icon-Only Links in Astro Components
+**Learning:** Decorative icons in `<a>` tags inside Astro components need specific attributes to be screen-reader friendly. Without a dynamic `aria-label` on the anchor and `alt="" aria-hidden="true"` on the image, screen readers may announce the image source URL, leading to a confusing and noisy user experience.
+**Action:** Always ensure that icon-only links use `aria-label` on the `<a>` tag and explicitly hide the decorative `<img>` with `alt="" aria-hidden="true"`.

--- a/bun_output.txt
+++ b/bun_output.txt
@@ -1,0 +1,14 @@
+$ astro dev
+09:52:35 [types] Generated 1ms
+09:52:35 [content] Syncing content
+09:52:35 [content] Synced content
+09:52:35 [vite] Re-optimizing dependencies because vite config has changed
+
+ astro  v5.17.3 ready in 342 ms
+
+┃ Local    http://localhost:4321/
+┃ Network  use --host to expose
+
+09:52:35 watching for file changes...
+09:53:21 [200] / 61ms
+09:53:25 [200] /cv 21ms

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,14 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li>
+			<img
+				src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`}
+				alt=""
+				aria-hidden="true"
+			/>
+			<a href={item.url}>{item.title}</a>
+		</li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,15 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li>
+			<a href={item.url} aria-label={item.title}>
+				<img
+					src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`}
+					alt=""
+					aria-hidden="true"
+				/>
+			</a>
+		</li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 What: Added `aria-label` to the `<a>` tags for icon-only links in `SocialGrid.astro` and explicitly hid decorative `<img>` tags from screen readers using `alt="" aria-hidden="true"` in both `SocialGrid.astro` and `LinkGrid.astro`.
🎯 Why: Without these attributes, screen readers might not announce anything useful for icon-only links (or worse, announce the image source URL), causing confusion. Hiding decorative images prevents noisy, redundant announcements.
📸 Before/After: Visual presentation remains exactly the same, but the underlying HTML is now semantically correct for assistive technologies.
♿ Accessibility: Improved screen reader experience by providing clear, text-based labels for interactive elements and hiding non-informative decorative visuals.

---
*PR created automatically by Jules for task [16183785380246773308](https://jules.google.com/task/16183785380246773308) started by @jgeofil*