### PR TITLE
🛡️ Sentinel: [HIGH] Add global Vercel security headers

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Global Security Headers in Vercel Deployment
+**Vulnerability:** Missing security headers (CSP, X-Frame-Options, etc.). By default, Vercel deployments do not have strict security headers applied, which could leave the application vulnerable to basic attacks like clickjacking and XSS.
+**Learning:** For Astro projects deployed on Vercel, global security headers can be applied via a `vercel.json` file in the root directory. This provides a simple, centralized way to add defense-in-depth across the entire application without needing to modify individual Astro pages or endpoints.
+**Prevention:** Always include a baseline `vercel.json` with security headers (like `X-Frame-Options`, `Strict-Transport-Security`, `X-XSS-Protection`, `X-Content-Type-Options`, and `Referrer-Policy`) when deploying static sites or Astro apps to Vercel to ensure defense-in-depth from the start.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing security headers (CSP, X-Frame-Options, etc.). By default, Vercel deployments do not have strict security headers applied, which could leave the application vulnerable to basic attacks like clickjacking and XSS.
🎯 Impact: Without these headers, users could be susceptible to clickjacking attacks (framing the site maliciously) or basic cross-site scripting vulnerabilities that modern browsers can otherwise block.
🔧 Fix: Added a `vercel.json` file to the root directory applying a comprehensive set of defense-in-depth security headers (`X-Frame-Options`, `Strict-Transport-Security`, `X-XSS-Protection`, `X-Content-Type-Options`, and `Referrer-Policy`) globally to all routes.
✅ Verification: Ensure the project continues to build properly (`bun run build`) and headers are applied in the Vercel deployment environment.

---
*PR created automatically by Jules for task [17299775704091640619](https://jules.google.com/task/17299775704091640619) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Security headers applied to all application routes for enhanced protection against common web vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->