### PR TITLE
⚡ Bolt: dynamically import non-critical analytics to improve initial load speed

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize Script Execution and Improve Code Splitting in Astro Layouts
+**Learning:** In Astro, statically importing heavy third-party tracking libraries inside a component script causes them to be aggressively bundled and loaded alongside the initial client payload, even if their initialization depends on environment variables. This creates unnecessary render blocking and inflates the bundle size for users.
+**Action:** When tracking libraries like Statsig or Web Vitals are conditional (based on an environment variable or flag), wrap them in dynamic `import()` blocks. This splits the code, prevents render blocking, and defers loading until the condition is met, drastically improving initial load performance.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,33 +37,42 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
-            import { webVitals } from "../lib/vitals";
-
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
             let statsigKey = import.meta.env.PUBLIC_STATSIG_CLIENT_KEY;
 
+            // ⚡ Bolt: Dynamically import non-critical tracking libraries.
+            // This enables code splitting, prevents render blocking, and reduces the initial JS payload size.
             if (analyticsId) {
-                webVitals({
-                    path: location.pathname,
-                    params: location.search,
-                    analyticsId,
-                });
+                import("../lib/vitals").then(({ webVitals }) => {
+                    webVitals({
+                        path: location.pathname,
+                        params: location.search,
+                        analyticsId,
+                    });
+                }).catch(console.error);
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin }
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What**: Refactored the loading of third-party analytics packages (Statsig and Vercel Analytics) in `src/layouts/Layout.astro` to use dynamic imports.
🎯 **Why**: Statically importing heavy tracking libraries causes them to be aggressively bundled into the initial client payload, causing render-blocking and decreasing initial page load performance, even when their initialization logic is conditional based on environment variables.
📊 **Impact**: Reduces the initial JS bundle size and stops render-blocking, drastically improving page load times for all users.
🔬 **Measurement**: Verify by running `bun run build` and checking the generated `.vercel/output/static` files to see that Statsig and analytics code is now split into separate chunks that are loaded on demand.

---
*PR created automatically by Jules for task [7910250837667887283](https://jules.google.com/task/7910250837667887283) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing a performance optimization for tracking library loading.

* **Refactor**
  * Optimized initialization of analytics and tracking libraries to load dynamically when needed instead of blocking initial page load. This reduces JavaScript payload and improves overall performance while maintaining functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->