### PR TITLE
🛡️ Sentinel: [MEDIUM] Add global security headers

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773047356566
 	}
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers. The app currently does not enforce HSTS, prevent clickjacking, or block MIME-type sniffing by default.
🎯 Impact: Attackers could potentially downgrade connections (lack of HSTS), embed the site in malicious iframes (clickjacking/UI redressing), or exploit MIME-type confusion vulnerabilities.
🔧 Fix: Created a `vercel.json` configuration to globally apply standard security headers (`Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, and `Referrer-Policy`) to all routes (`/(.*)`).
✅ Verification: Ensure the app builds (`bun run build`) without errors. Once deployed on Vercel, inspect the HTTP response headers in the browser developer tools to verify the security headers are present.

---
*PR created automatically by Jules for task [12339089815894804396](https://jules.google.com/task/12339089815894804396) started by @jgeofil*