### PR TITLE
🛡️ Sentinel: [security improvement] Add global security headers

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-10 - Add Global Security Headers via Vercel Configuration
+**Vulnerability:** Missing security headers (CSP, X-Frame-Options, HSTS, etc.) on the deployed Astro application.
+**Learning:** For Astro projects deployed on Vercel, global HTTP headers aren't inherently managed by the Astro configuration alone but require a `vercel.json` file to enforce headers across all routes (`/(.*)`).
+**Prevention:** Always verify if a `vercel.json` or equivalent hosting configuration exists and ensure standard security headers (e.g., `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, `Referrer-Policy`) are applied globally to prevent various classes of attacks (like clickjacking and MIME-type sniffing).

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers (CSP, X-Frame-Options, HSTS, etc.) on the deployed Astro application.
🎯 Impact: This could allow attacks like clickjacking, MIME-type sniffing, or insecure transport, as standard protections are absent.
🔧 Fix: Configured `vercel.json` to enforce standard security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Strict-Transport-Security`, `Referrer-Policy`) globally (`/(.*)`). Documented the findings in the `.jules/sentinel.md` journal.
✅ Verification: Ran `bun test` and verified project builds via `bun run build`.

---
*PR created automatically by Jules for task [17518252212785249285](https://jules.google.com/task/17518252212785249285) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced application security by implementing global security headers across all routes, protecting against clickjacking, content-type sniffing, XSS attacks, and enforcing HTTPS with HSTS preload. Additional referrer policy controls restrict cross-origin information leakage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->