### PR TITLE
⚡ Bolt: Optimize Statsig layout imports

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773132289123
 	}
 }

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Dynamic imports for non-critical third-party libraries
+**Learning:** In Astro layouts, static imports for large third-party libraries like Statsig analytics (e.g., `@statsig/js-client`, `@statsig/session-replay`, `@statsig/web-analytics`) block rendering and increase the initial payload significantly.
+**Action:** Use dynamic imports (`import()`) inside a conditional check (`if (statsigKey)`) to load these non-critical libraries. This allows code splitting, preventing them from blocking the initial page render.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,22 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics"),
+                ]).then(([{ StatsigClient }, { StatsigSessionReplayPlugin }, { StatsigAutoCapturePlugin }]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What:** Refactored static imports for Statsig analytics (`@statsig/js-client`, `@statsig/session-replay`, `@statsig/web-analytics`) into dynamic `import()` calls inside the conditional `if (statsigKey)` block in `src/layouts/Layout.astro`.
🎯 **Why:** Static imports block rendering and increase the initial payload significantly, even if the user doesn't have a `statsigKey` set up. Dynamic imports allow for code splitting and non-blocking loading of these third-party libraries.
📊 **Impact:** Reduces initial JS payload size and improves initial page load speed by extracting Statsig libraries from the main client chunk (verified by empty chunk warning during `bun run build`).
🔬 **Measurement:** Run `bun run build`. You'll notice `Layout.astro` generates smaller initial chunks. Also visually verified no regressions on the homepage.

---
*PR created automatically by Jules for task [6998496991664784490](https://jules.google.com/task/6998496991664784490) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initial page load performance by deferring non-critical analytics library initialization until needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->