### PR TITLE
⚡ Bolt: Use dynamic imports for conditional analytics

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Use dynamic imports for conditional third-party scripts
+**Learning:** Statically importing heavy third-party libraries (like Statsig analytics) in Astro layout scripts forces their inclusion in the initial client bundle, even if their initialization is conditional. This bloats the initial payload and can block rendering.
+**Action:** Use dynamic imports (`import()`) for such libraries to enable code splitting. This ensures they are only downloaded when the condition is met, significantly reducing the initial client payload size.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,24 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // ⚡ Bolt: Use dynamic imports for Statsig libraries to enable code splitting
+                // and prevent downloading these large dependencies when not needed (e.g., if statsigKey is empty).
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([{ StatsigClient }, { StatsigSessionReplayPlugin }, { StatsigAutoCapturePlugin }]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What**: Refactored the `src/layouts/Layout.astro` file to use dynamic `import()` for the three Statsig libraries (`@statsig/js-client`, `@statsig/session-replay`, and `@statsig/web-analytics`) inside the conditional `if (statsigKey)` block, rather than importing them statically at the top of the script.

🎯 **Why**: Statically importing these libraries forces them to be included in the initial client JavaScript bundle, bloating the payload size and potentially blocking the main thread during parsing, even if `statsigKey` is not present (i.e., tracking is disabled or not configured).

📊 **Impact**: Reduces the initial JavaScript bundle size by splitting the analytics dependencies into separate chunks. These chunks are only downloaded over the network if the tracking condition is met, leading to faster Time to Interactive (TTI) and smaller initial payloads for users where analytics are not required.

🔬 **Measurement**: Run `bun run build` and inspect the output. You should observe that Astro/Vite now generates separate chunks for the Statsig libraries rather than bundling them into the main entry script.

---
*PR created automatically by Jules for task [15401243003884311379](https://jules.google.com/task/15401243003884311379) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized application startup performance with improved dependency loading.

* **Documentation**
  * Added development notes on conditional dependency loading patterns for optional features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->