### PR TITLE
⚡ Bolt: Dynamically import Statsig to enable code splitting

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,35 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // ⚡ Bolt: Dynamically import Statsig dependencies to enable code splitting
+                // Impact: Reduces the initial JS payload by moving analytics/replay SDKs to a separate chunk.
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics"),
+                ])
+                    .then(
+                        ([
+                            { StatsigClient },
+                            { StatsigSessionReplayPlugin },
+                            { StatsigAutoCapturePlugin },
+                        ]) => {
+                            const statsig = new StatsigClient(
+                                statsigKey,
+                                {},
+                                {
+                                    plugins: [
+                                        new StatsigAutoCapturePlugin(),
+                                        new StatsigSessionReplayPlugin(),
+                                    ],
+                                },
+                            );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                            // Initialize
+                            statsig.initializeAsync().catch(console.error);
+                        },
+                    )
+                    .catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 What: Updated `src/layouts/Layout.astro` to use dynamic imports for `StatsigClient`, `StatsigSessionReplayPlugin`, and `StatsigAutoCapturePlugin`.
🎯 Why: Statically importing these large analytics SDKs bundles them into the main entry point, blocking the main thread and bloating the initial payload for all users, even if the analytics key isn't provided.
📊 Impact: Reduces the initial JavaScript payload by moving the analytics and session replay SDKs into a separate chunk, improving load performance and preventing render blocking.
🔬 Measurement: Run `bun run build` and inspect the chunk output. The main bundle size should decrease, and new chunks will be generated for the Statsig dependencies.

---
*PR created automatically by Jules for task [10211693549295669603](https://jules.google.com/task/10211693549295669603) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Optimized resource loading with enhanced error handling and stability improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->