### PR TITLE
⚡ Bolt: Optimize Astro layout by dynamically importing third-party scripts

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773392657106
 	}
 }

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Dynamically importing optional 3rd-party libs in Astro
+**Learning:** Statically importing third-party libraries (like web analytics or session replay tools) in Astro layouts forces these scripts to be included in the main bundle. This inflates the initial payload size and blocks rendering, even when the functionality isn't guaranteed to run (e.g. conditional on an API key being present).
+**Action:** Use dynamic `import()` for non-critical, conditionally loaded scripts within Astro component scripts. This utilizes Astro's built-in code-splitting, deferring the load of these libraries until they are actually needed and reducing the impact on Time To Interactive (TTI) and First Contentful Paint (FCP).

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,33 +37,42 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
-            import { webVitals } from "../lib/vitals";
-
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
             let statsigKey = import.meta.env.PUBLIC_STATSIG_CLIENT_KEY;
 
             if (analyticsId) {
-                webVitals({
-                    path: location.pathname,
-                    params: location.search,
-                    analyticsId,
+                // Optimization: dynamically import web vitals to reduce initial bundle size and non-blocking render
+                import("../lib/vitals").then(({ webVitals }) => {
+                    webVitals({
+                        path: location.pathname,
+                        params: location.search,
+                        analyticsId,
+                    });
                 });
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Optimization: dynamically import statsig to enable code splitting, reduce initial payload, and non-blocking render
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin }
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                });
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What:** Replaced static imports of Statsig analytics and Web Vitals libraries with dynamic `import()` statements inside the respective `if (analyticsId)` and `if (statsigKey)` conditional blocks in `src/layouts/Layout.astro`.
🎯 **Why:** Statically importing third-party libraries in Astro layouts forces them to be included in the main bundle, even if the conditionals preventing their initialization evaluate to false (e.g., missing API keys). This inflates the initial payload size and blocks rendering.
📊 **Impact:** Reduces the initial JavaScript bundle size by code-splitting the heavy `@statsig/*` and Web Vitals libraries, deferring their load until runtime and improving Time To Interactive (TTI) and First Contentful Paint (FCP).
🔬 **Measurement:** Verify the reduction in the main bundle size using tools like Lighthouse or Chrome DevTools Network tab. Check that the functionality of Web Vitals and Statsig remains intact when the respective environment variables are provided.

---
*PR created automatically by Jules for task [17370723594317146170](https://jules.google.com/task/17370723594317146170) started by @jgeofil*