### PR TITLE
🎨 Palette: Improve accessibility of icon links and images

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773392827658
 	}
 }

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Accessible Icon Links and Images
+**Learning:** Icon-only links and decorative images in Astro components need explicit accessibility attributes. Screen readers may misinterpret or announce unhelpful filenames for decorative images if `alt` text is missing. Icon-only links lack text content for screen readers to announce their purpose.
+**Action:** When creating icon-only links (e.g., `SocialGrid`), use dynamic `aria-label` attributes on the `<a>` tags. For purely decorative images accompanying links (e.g., `LinkGrid` and `SocialGrid`), explicitly hide them from assistive technologies using `alt=""` and `aria-hidden="true"`.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What:** 
- Added dynamic `aria-label` attributes to the `<a>` tags in `SocialGrid.astro` to provide an accessible name for screen readers.
- Added `alt=""` and `aria-hidden="true"` to the decorative `<img>` tags in `SocialGrid.astro` and `LinkGrid.astro` to hide them from assistive technologies.
- Created a `.jules/palette.md` journal entry to document this critical accessibility learning.

🎯 **Why:** 
- Icon-only links lack text content, meaning screen readers cannot announce their purpose without an accessible name (like `aria-label`).
- Decorative images that accompany links should be explicitly hidden from screen readers to prevent them from announcing unhelpful filenames or URLs, reducing noise for users relying on assistive technologies.

📸 **Before/After:** No visual changes were made; the improvements are structural (HTML attributes).

♿ **Accessibility:** 
- Improved screen reader navigation for the social links grid by providing clear, descriptive accessible names.
- Reduced noise for screen reader users by properly hiding purely decorative icons accompanying text links.

---
*PR created automatically by Jules for task [7974404406399331997](https://jules.google.com/task/7974404406399331997) started by @jgeofil*