### PR TITLE
🎨 Palette: Improve accessibility for icon links in SocialGrid and LinkGrid

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773477579093
 	}
 }

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Icon Links in Astro Components
+**Learning:** Purely icon-based links (like in SocialGrid) or links with purely decorative icons (like in LinkGrid) need to be explicitly managed for screen readers in Astro components. Specifically, `<img>` tags for decorative icons need `alt=""` and `aria-hidden="true"`, and the wrapping `<a>` elements for icon-only links need a dynamic `aria-label`.
+**Action:** When creating or modifying Astro components with icon links or decorative images, ensure `<a>` elements have `aria-label` attributes if they only contain an icon, and ensure purely visual `<img>` tags use `alt=""` and `aria-hidden="true"`.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,10 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li>
+			<img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" />
+			<a href={item.url}>{item.title}</a>
+		</li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,11 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li>
+			<a href={item.url} aria-label={item.title}>
+				<img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" />
+			</a>
+		</li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the `<a>` tags in `SocialGrid.astro` and added `alt=""` and `aria-hidden="true"` to the decorative `<img>` tags in both `SocialGrid.astro` and `LinkGrid.astro`. Documented this learning in the `.jules/palette.md` journal.
🎯 **Why:** To improve accessibility for users relying on screen readers. Previously, icon-only links in `SocialGrid` lacked context, and decorative icons in both components were not explicitly hidden, potentially causing clutter or confusion for assistive technologies.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Icon-only links are now properly announced by screen readers with their dynamic titles, and purely visual decorative images are ignored.

---
*PR created automatically by Jules for task [635541001836512784](https://jules.google.com/task/635541001836512784) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced icon links and decorative images with proper screen reader compatibility attributes, improving accessibility for users relying on assistive technologies.
  * Added accessible labels to social and link grid components for better screen reader support.

* **Documentation**
  * Added accessibility guidelines for icon links to support best practices in component development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->