### PR TITLE
⚡ Bolt: Dynamic import analytics libraries for smaller initial payload

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,33 +37,40 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
-            import { webVitals } from "../lib/vitals";
-
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
             let statsigKey = import.meta.env.PUBLIC_STATSIG_CLIENT_KEY;
 
+            // ⚡ Bolt: Use dynamic imports for non-critical analytics libraries.
+            // This optimization enables code splitting, prevents render blocking, and
+            // significantly reduces the initial client payload size when analytics are disabled or unused.
+
             if (analyticsId) {
-                webVitals({
-                    path: location.pathname,
-                    params: location.search,
-                    analyticsId,
-                });
+                import("../lib/vitals").then(({ webVitals }) => {
+                    webVitals({
+                        path: location.pathname,
+                        params: location.search,
+                        analyticsId,
+                    });
+                }).catch(console.error);
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([{ StatsigClient }, { StatsigSessionReplayPlugin }, { StatsigAutoCapturePlugin }]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What:** Switched from static to dynamic imports for `StatsigClient`, `StatsigSessionReplayPlugin`, `StatsigAutoCapturePlugin`, and `webVitals` in `src/layouts/Layout.astro`.

🎯 **Why:** Analytics and session replay libraries are not critical for the initial visual rendering of the page. Statically importing them at the top level forces the browser to download, parse, and execute them before main content becomes interactive (render blocking), unnecessarily increasing the initial JS payload, especially when analytics are disabled (e.g., in local development without API keys).

📊 **Impact:** Reduces the initial main-thread JS payload size, eliminates render blocking from these scripts, and enables proper code splitting. The libraries are only fetched and executed when `analyticsId` or `statsigKey` are present.

🔬 **Measurement:**
- Verified `bun run build` succeeds, generating static routes properly.
- Visually verified via Playwright that the page still renders perfectly.
- In Chrome DevTools (Network > JS), the analytics scripts will now appear as separate chunks loaded asynchronously, rather than being bundled into the main entry point.

---
*PR created automatically by Jules for task [13257661220285879276](https://jules.google.com/task/13257661220285879276) started by @jgeofil*