### PR TITLE
🎨 Palette: Improve accessibility of icon links

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve accessibility of icon links
+**Learning:** Purely decorative images or icons used alongside or inside links need to be hidden from screen readers using `alt="" aria-hidden="true"`, otherwise they create unnecessary noise. If an icon is the *only* content of a link, the link must have a descriptive `aria-label` so its purpose is clear to screen reader users.
+**Action:** When adding or modifying links with icons, ensure that screen reader context is correctly provided via text or `aria-label` on the anchor tag, and that decorative icons are appropriately hidden.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What**: Added `aria-label` to the link anchor tags in `SocialGrid.astro` and added `alt="" aria-hidden="true"` to decorative images in both `SocialGrid.astro` and `LinkGrid.astro`. Also, added a journal entry in `.jules/palette.md` for this accessibility learning.

🎯 **Why**: To improve the experience for screen reader users. Without these changes, screen readers might announce the raw URL for icon-only links (like the social links) or announce repetitive/meaningless information for the decorative icons next to text links. 

📸 **Before/After**: Visuals remain identical, but screen reader experience is vastly improved. 

♿ **Accessibility**: 
- Added `aria-label` dynamically based on the link's `title` property in `SocialGrid`.
- Used `alt="" aria-hidden="true"` to hide decorative `<img>` tags.

---
*PR created automatically by Jules for task [369948601092629502](https://jules.google.com/task/369948601092629502) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added accessibility guidelines for icon links, including best practices for decorative and semantic icons with proper ARIA attributes.

* **Accessibility**
  * Enhanced screen reader compatibility across components by implementing proper accessibility attributes on icon elements and improving link descriptions for assistive technology support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->