### PR TITLE
🛡️ Sentinel: [security improvement] Add missing security headers

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-15 - Missing Default Security Headers in Vercel Deployment
+**Vulnerability:** The Astro application deployed to Vercel was missing standard HTTP security headers such as `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, and `Strict-Transport-Security`.
+**Learning:** Vercel deployments do not automatically add global security defenses/headers to routes by default. They must be explicitly configured.
+**Prevention:** Always include a `vercel.json` file in the root directory configured with standard security headers under the `headers` key matching the `/(.*)` route when deploying Astro apps (or any app) to Vercel.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers such as `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, and `Strict-Transport-Security`. By default Vercel deployments do not automatically add global security defenses/headers to routes.
🎯 Impact: This exposes the application to common attacks like clickjacking, XSS, and MIME-type sniffing.
🔧 Fix: Created a `vercel.json` file in the root directory configured with standard security headers matching all routes `/(.*)`. Documented the lack of default security headers in Vercel to `.jules/sentinel.md`.
✅ Verification: Ran `bun test` and `bun run build` to verify the application successfully builds with the change.

---
*PR created automatically by Jules for task [15450281715898268943](https://jules.google.com/task/15450281715898268943) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type declarations to include content module references.
  * Configured HTTP security headers globally for all deployment routes, enforcing X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Strict-Transport-Security, and Referrer-Policy standards.

* **Documentation**
  * Added documentation addressing HTTP security header configurations for Vercel deployments, including vulnerability assessment and recommended header values for deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->