### PR TITLE
⚡ Bolt: dynamically import statsig dependencies

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773650952863
 	}
 }

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Dynamic Imports in Astro Layouts]
+**Learning:** [Astro does not split chunks correctly for statically imported third party scripts that are conditionally evaluated based on an environment variable using if/else]
+**Action:** [Use dynamic imports using `Promise.all` + `import` to correctly split out these chunks from the client payload size to prevent render blocking]

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,28 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Dynamically import Statsig dependencies only if statsigKey is present.
+                // This optimization enables code splitting, prevents render blocking, and reduces the initial client payload size.
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics"),
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin },
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 What: Converted static imports for `@statsig/js-client`, `@statsig/session-replay`, and `@statsig/web-analytics` to dynamic imports (`import()`) within the `if (statsigKey)` conditional block in `src/layouts/Layout.astro`.
🎯 Why: Statically imported dependencies are bundled into the main client payload, even if they are only used conditionally based on an environment variable. This causes unnecessary render blocking and slower time-to-interactive for users who do not have the analytics key present. 
📊 Impact: This optimization enables Vite (Astro's bundler) to successfully code-split these heavy third-party plugins into separate chunks. These chunks are now only fetched and executed when `statsigKey` is configured, reducing the initial JavaScript payload size and saving main-thread execution time.
🔬 Measurement: Verify by running `bun run build`. In the build output, you will no longer see the large chunks associated with Statsig if the key is not set, or you can inspect the generated bundles in `dist/client/`. You can also visually inspect that the UI still renders correctly on `localhost:4321`.

---
*PR created automatically by Jules for task [17256189808056648368](https://jules.google.com/task/17256189808056648368) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Enhanced initial page load performance by deferring non-critical third-party library loading, reducing payload size and preventing render blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->