### PR TITLE
🛡️ Sentinel: [security improvement] Add global security headers via vercel.json

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing global security headers for Vercel deployment
+**Vulnerability:** The project is deployed on Vercel, but Vercel lacks default global security headers such as `X-Frame-Options`, `Strict-Transport-Security`, `X-XSS-Protection`, etc. This could potentially allow attacks like clickjacking, XSS, and downgrade attacks.
+**Learning:** Default Vercel deployments do not automatically add essential security headers for all routes. We must explicitly define them via a `vercel.json` configuration file.
+**Prevention:** Always verify and include a `vercel.json` with recommended global security headers when deploying Astro/React applications to Vercel, ensuring all routes (e.g., `/(.*)`) are protected.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,29 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The project is deployed on Vercel, but Vercel lacks default global security headers (like `X-Frame-Options`, `Strict-Transport-Security`, `X-XSS-Protection`). This missing defense-in-depth configuration leaves the application more vulnerable to common attacks such as clickjacking and XSS.

🎯 **Impact:** Without explicit security headers, the site could be embedded in malicious iframes, browsers might try to MIME-sniff content types improperly, and HSTS protections for subdomains wouldn't be strictly enforced. 

🔧 **Fix:** Added a `vercel.json` file to the root of the project to explicitly define standard global security headers for all routes (`/(.*)`), applying recommended values. Also documented this Vercel deployment specific learning in `.jules/sentinel.md`.

✅ **Verification:** Verified by checking the exact contents of `vercel.json` and successfully running `bun install`, `bun test`, and `bun run build` to ensure the configuration introduces no syntax or build errors.

---
*PR created automatically by Jules for task [11187377170473987044](https://jules.google.com/task/11187377170473987044) started by @jgeofil*