### PR TITLE
🎨 Palette: Improve accessibility of icon links

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773651810135
 	}
 }

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Hiding decorative images and labeling icon-only links in Astro components
+**Learning:** Icon-only links in Astro components (e.g., SocialGrid) lack context for assistive technologies without an explicit aria-label. Additionally, purely decorative images accompanying links (e.g., in LinkGrid) must be explicitly hidden from screen readers using `alt="" aria-hidden="true"` to reduce noise.
+**Action:** Always verify that icon-only links have a descriptive `aria-label` generated dynamically (e.g., `aria-label={item.title}`). Ensure that purely decorative `<img>` tags are marked with `alt="" aria-hidden="true"`.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to icon-only links in `SocialGrid.astro` based on their title and added `alt="" aria-hidden="true"` to purely decorative images in both `SocialGrid.astro` and `LinkGrid.astro`.
🎯 **Why**: To improve accessibility for screen readers. Icon-only links lacked context without an explicit `aria-label`, and decorative images created unnecessary noise for assistive technologies.
📸 **Before/After**: Visually unchanged.
♿ **Accessibility**: Significant improvement in screen reader experience by providing context to icon links and hiding decorative images.

---
*PR created automatically by Jules for task [17565873560835512253](https://jules.google.com/task/17565873560835512253) started by @jgeofil*