### PR TITLE
🎨 Palette: Improve screen reader accessibility for icon links and decorative images

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773736927231
 	}
 }

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-17 - Improve Accessibility for Decorative Images and Icon Links
+**Learning:** Icon-only links and purely decorative images in custom Astro components lack out-of-the-box accessibility (like ARIA labels and hidden tags) preventing screen readers from understanding their meaning or purposely ignoring them.
+**Action:** Always add `aria-label` dynamically to icon-only links and explicitly hide accompanying decorative images using `alt=""` and `aria-hidden="true"` to improve assistive technology experiences.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What**:
Added `aria-label` attributes to the icon-only social links in the `SocialGrid` component. Additionally, explicitly hid the purely decorative icons within `SocialGrid` and `LinkGrid` from screen readers by adding `alt=""` and `aria-hidden="true"`.

🎯 **Why**:
Icon-only links without accessible names are invisible to screen readers, making it difficult or impossible for visually impaired users to understand where the link leads. Purely decorative images (like icons paired with text links in `LinkGrid`) create redundant or confusing "noise" for screen reader users.

📸 **Before/After**:
Visually, the UI remains exactly the same. The changes are strictly within the HTML markup for assistive technologies.

♿ **Accessibility**:
- Social links now announce their intended destination (e.g., "LinkedIn", "Scholar") to screen readers instead of reading out raw URLs or remaining completely silent.
- Screen readers will skip over the decorative images, reducing cognitive load and providing a cleaner, more streamlined reading experience.

---
*PR created automatically by Jules for task [4876097596270078384](https://jules.google.com/task/4876097596270078384) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility for decorative images and icon-only links by adding proper ARIA labels and hidden attributes, improving screen reader support and assistive technology compatibility across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->