### PR TITLE
⚡ Bolt: Use dynamic imports for analytics to reduce initial payload

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773737250154
 	}
 }

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-17 - Astro Static vs Dynamic Imports for Analytics
+**Learning:** Astro does not split chunks correctly for statically imported scripts conditionally evaluated via environment variables. This causes non-critical libraries to block rendering and increase initial bundle size.
+**Action:** Use dynamic imports (e.g., `Promise.all([import()])`) for non-critical or conditional third-party libraries in Astro layouts to enable proper code splitting.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,33 +37,42 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
-            import { webVitals } from "../lib/vitals";
-
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
             let statsigKey = import.meta.env.PUBLIC_STATSIG_CLIENT_KEY;
 
             if (analyticsId) {
-                webVitals({
-                    path: location.pathname,
-                    params: location.search,
-                    analyticsId,
+                // Optimize: Use dynamic import to prevent render blocking and split chunks
+                import("../lib/vitals").then(({ webVitals }) => {
+                    webVitals({
+                        path: location.pathname,
+                        params: location.search,
+                        analyticsId,
+                    });
                 });
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Optimize: Use dynamic imports for conditional analytics to reduce initial payload
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin }
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 **What**: Replaced static imports of `StatsigClient`, `webVitals`, and Statsig plugins with dynamic imports (`import()`) in `src/layouts/Layout.astro`.
🎯 **Why**: Astro does not split chunks correctly for statically imported scripts that are only evaluated conditionally (via environment variables). This caused these non-critical, third-party libraries to block rendering and increase the initial client payload size unnecessarily.
📊 **Impact**: Reduces initial JavaScript bundle size significantly. Analytics scripts will now only be downloaded and parsed asynchronously when their corresponding environment variables are present, improving First Contentful Paint (FCP) and Time to Interactive (TTI).
🔬 **Measurement**: Verified by running `bun run build` and checking the generated chunks. A new chunk is now correctly split out for these scripts. The change was also verified locally with `bun run dev` and a Playwright test to ensure no visual regressions occurred.

Also added a journal entry in `.jules/bolt.md` documenting this Astro chunking behavior.

---
*PR created automatically by Jules for task [13111389633166994017](https://jules.google.com/task/13111389633166994017) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized initial load performance by deferring analytics and feature management library initialization until needed.

* **Documentation**
  * Added internal guidance on best practices for code splitting in static site generation.

* **Chores**
  * Updated configuration timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->