### PR TITLE
⚡ Bolt: Use dynamic imports for analytics to improve initial load time

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Dynamic imports in Astro components
+**Learning:** Astro does not correctly split chunks for statically imported scripts conditionally evaluated via environment variables. For non-critical or conditional third-party libraries (like analytics) in Astro layouts, use dynamic imports (`import()`) to enable code splitting, prevent render blocking, and reduce the initial client payload size.
+**Action:** Always prefer dynamic `import()` inside `if` blocks for optional scripts rather than top-level static imports in Astro components.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,33 +37,42 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
-            import { webVitals } from "../lib/vitals";
-
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
             let statsigKey = import.meta.env.PUBLIC_STATSIG_CLIENT_KEY;
 
             if (analyticsId) {
-                webVitals({
-                    path: location.pathname,
-                    params: location.search,
-                    analyticsId,
+                // Optimize: Use dynamic import for webVitals to prevent render blocking
+                import("../lib/vitals.js").then(({ webVitals }) => {
+                    webVitals({
+                        path: location.pathname,
+                        params: location.search,
+                        analyticsId,
+                    });
                 });
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Optimize: Use dynamic imports for Statsig to enable code splitting and reduce initial client payload size
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([
+                    { StatsigClient },
+                    { StatsigSessionReplayPlugin },
+                    { StatsigAutoCapturePlugin }
+                ]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                });
             }
         </script>
     </head>


### PR DESCRIPTION
💡 What: Refactored `src/layouts/Layout.astro` to use dynamic imports for `webVitals` and Statsig libraries (`@statsig/js-client`, `@statsig/session-replay`, `@statsig/web-analytics`) instead of top-level static imports.

🎯 Why: Astro does not properly code-split chunks for statically imported scripts that are conditionally evaluated inside `<script>` blocks (e.g., behind environment variable checks). This meant the entire payload of these analytics libraries was blocking the initial render and increasing the client bundle size even if the environment variables were absent.

📊 Impact: Reduces initial client payload size by allowing Vite/Rollup to split these libraries into separate chunks. Prevents render blocking during the initial page load, improving metrics like FCP and LCP.

🔬 Measurement: Verify by running `bun run build`. The build output should indicate smaller initial chunks and confirm successful compilation. Comparing network tab payload sizes on initial load will show a reduction.

---
*PR created automatically by Jules for task [522721438485337948](https://jules.google.com/task/522721438485337948) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on optimizing code splitting and dynamic imports in components.

* **Refactor**
  * Improved application load performance by deferring initialization of non-critical modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->