### PR TITLE
🎨 Palette: Improve accessibility for icon links and decorative images

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1771971506721
+		"lastUpdateCheck": 1773824330600
 	}
 }

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve accessibility for icon links and decorative images
+**Learning:** Icon-only links in Astro components (e.g., SocialGrid) lack screen reader context, and decorative images (e.g., LinkGrid) can add noise if not hidden from assistive technologies.
+**Action:** Always add dynamic `aria-label` attributes to icon-only links using data sources like `cv.json` (e.g., `item.title`), and explicitly hide purely decorative images accompanying links using `alt=""` and `aria-hidden="true"`.

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /><a href={item.url}>{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} aria-label={item.title}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What:**
Added dynamic `aria-label` attributes to icon-only links in `SocialGrid.astro` using `item.title` from the data source. Also explicitly hid purely decorative images accompanying links in both `SocialGrid.astro` and `LinkGrid.astro` using `alt=""` and `aria-hidden="true"`.

🎯 **Why:**
Screen reader users navigating through icon-only links without `aria-label` receive no context about the destination. Furthermore, decorative images (like link icons) can add unnecessary noise when read by assistive technologies since the adjacent text already provides the context.

📸 **Before/After:**
*Visuals remain unchanged.* This is purely a markup/accessibility improvement.

♿ **Accessibility:**
- Ensures screen readers can announce the purpose of social links.
- Removes redundant or unhelpful image announcements from the accessibility tree.

---
*PR created automatically by Jules for task [18293993503949721259](https://jules.google.com/task/18293993503949721259) started by @jgeofil*