### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in analytics URLs

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-19 - Sensitive Data Exposure in Analytics URLs
+**Vulnerability:** The application was sending the full `location.href` to Vercel Analytics, which could unintentionally expose sensitive data (like PII or authentication tokens) present in query parameters or hash fragments.
+**Learning:** Analytics reporting endpoints must sanitize URLs to prevent leaking sensitive information that might be part of a user's current session state or redirect parameters.
+**Prevention:** Always use `location.origin + location.pathname` instead of `location.href` or `location.search` when reporting page views or interactions to third-party analytics services, ensuring that query strings and hash fragments are explicitly stripped out.

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -25,7 +25,7 @@ export function sendToAnalytics(metric, options) {
 		dsn: options.analyticsId,
 		id: metric.id,
 		page,
-		href: location.href,
+		href: location.origin + location.pathname, // Sanitized URL to avoid leaking query strings/hashes
 		event_name: metric.name,
 		value: metric.value.toString(),
 		speed: getConnectionSpeed(),


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was inadvertently sending the full `location.href` to Vercel Analytics inside `src/lib/vitals.js`. This exposes sensitive data (such as Personal Identifiable Information (PII) or authentication tokens) that might be present in URL query parameters or hash fragments.
🎯 **Impact:** Exposing sensitive tokens or PII to third-party analytics services creates a significant privacy and security risk, potentially leading to unauthorized access or data leakage.
🔧 **Fix:** Replaced `location.href` with `location.origin + location.pathname` to sanitize the URL payload. This effectively strips out query strings and hash fragments while still accurately reporting the page being viewed.
✅ **Verification:** Ran `bun install`, `bun test`, and `bun run build` to ensure the project still compiles correctly and the changes do not introduce any regressions. Verified the code change using the `read_file` tool. Created `.jules/sentinel.md` with the critical learning from this fix.

---
*PR created automatically by Jules for task [5725702216457771408](https://jules.google.com/task/5725702216457771408) started by @jgeofil*