### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in analytics tracking

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-20 - Sensitive Data Exposure in Analytics Tracking
+**Vulnerability:** The analytics tracking code in `src/lib/vitals.js` was using `location.href` directly to capture the page URL.
+**Learning:** This exposes the entire URL, including potentially sensitive query parameters (like PII, tokens, session IDs) and hash fragments to third-party analytics services, creating a high-risk data leakage scenario.
+**Prevention:** Always sanitize URLs before sending them to third-party services. Use `location.origin + location.pathname` to ensure query parameters and hashes are stripped from tracked analytics data.

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -25,7 +25,7 @@ export function sendToAnalytics(metric, options) {
 		dsn: options.analyticsId,
 		id: metric.id,
 		page,
-		href: location.href,
+		href: location.origin + location.pathname, // Sanitize to prevent PII exposure in query string
 		event_name: metric.name,
 		value: metric.value.toString(),
 		speed: getConnectionSpeed(),


### PR DESCRIPTION
* 🚨 **Severity**: HIGH
* 💡 **Vulnerability**: The analytics tracking code in `src/lib/vitals.js` was using `location.href` directly to capture the page URL for tracking events.
* 🎯 **Impact**: Using `location.href` exposes the entire URL, including any potentially sensitive query parameters (like PII, authentication tokens, session IDs, or password reset tokens) and hash fragments to third-party analytics services, creating a significant data leakage scenario.
* 🔧 **Fix**: Sanitized the URL before sending it to the analytics service by using `location.origin + location.pathname`. This ensures that all tracking still functions correctly for pages while completely stripping query strings and hashes. Also documented this critical learning in `.jules/sentinel.md`.
* ✅ **Verification**: Checked file contents and ran `bun test` and `bun run build` to verify the codebase compiles successfully without regressions.

---
*PR created automatically by Jules for task [11603267826406092490](https://jules.google.com/task/11603267826406092490) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics data now excludes sensitive information from URLs. Query parameters and fragments are no longer transmitted in analytics tracking.

* **Documentation**
  * Added documentation regarding sensitive data handling in analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->