### PR TITLE
⚡ Bolt: Optimize Statsig imports for code splitting

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-23 - Astro chunk splitting for conditionally evaluated scripts
+**Learning:** Astro does not correctly split chunks for statically imported scripts that are conditionally evaluated using environment variables. This results in the entire conditional script bundle (like Statsig analytics) being loaded synchronously, blocking rendering.
+**Action:** Always use dynamic imports (e.g., `Promise.all([import(...)])`) for non-critical, conditionally evaluated third-party libraries within Astro layouts to enable proper code splitting and reduce initial client payload size.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -37,9 +37,6 @@ const { title, description } = Astro.props as Props;
         <meta name="description" content={description} />
         <title>{title}</title>
         <script>
-            import { StatsigClient } from "@statsig/js-client";
-            import { StatsigSessionReplayPlugin } from "@statsig/session-replay";
-            import { StatsigAutoCapturePlugin } from "@statsig/web-analytics";
             import { webVitals } from "../lib/vitals";
 
             let analyticsId = import.meta.env.PUBLIC_VERCEL_ANALYTICS_ID;
@@ -54,16 +51,24 @@ const { title, description } = Astro.props as Props;
             }
 
             if (statsigKey) {
-                const statsig = new StatsigClient(
-                    statsigKey,
-                    {},
-                    {
-                        plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
-                    },
-                );
+                // Optimization: Use dynamic imports for Statsig to enable code splitting
+                // and prevent render blocking for this non-critical conditional script.
+                Promise.all([
+                    import("@statsig/js-client"),
+                    import("@statsig/session-replay"),
+                    import("@statsig/web-analytics")
+                ]).then(([{ StatsigClient }, { StatsigSessionReplayPlugin }, { StatsigAutoCapturePlugin }]) => {
+                    const statsig = new StatsigClient(
+                        statsigKey,
+                        {},
+                        {
+                            plugins: [new StatsigAutoCapturePlugin(), new StatsigSessionReplayPlugin()],
+                        },
+                    );
 
-                // Initialize
-                statsig.initializeAsync().catch(console.error);
+                    // Initialize
+                    statsig.initializeAsync().catch(console.error);
+                }).catch(console.error);
             }
         </script>
     </head>


### PR DESCRIPTION
💡 What: Refactored the Statsig analytics, session replay, and JS client static imports to use dynamic imports `Promise.all([import(...)])` within the conditionally evaluated `statsigKey` block in `src/layouts/Layout.astro`.

🎯 Why: Astro does not properly code-split conditionally evaluated static imports within scripts, leading to the entire Statsig bundle loading synchronously in the main thread layout. By dynamically importing these non-critical third-party analytics scripts, we prevent render-blocking and significantly reduce the initial JavaScript payload size.

📊 Impact: Reduces the initial layout JS payload by avoiding synchronous loading of `@statsig/js-client`, `@statsig/session-replay`, and `@statsig/web-analytics`.

🔬 Measurement: Verifiable by inspecting the generated Vite build chunks (via `bun run build`) or Chrome DevTools network tab. The Statsig chunks will now correctly split into asynchronous lazy-loaded files rather than being bundled in the primary layout chunk.

---
*PR created automatically by Jules for task [9849032432186682577](https://jules.google.com/task/9849032432186682577) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized script loading by switching to dynamic imports for conditionally evaluated scripts, preventing unnecessary bundle loading and reducing render-blocking behavior.

* **Documentation**
  * Added guidance on code splitting best practices for conditional script loading in layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->