### PR TITLE
Allow manual dispatch to run merge jobs

### DIFF
--- a/.github/workflows/merge-jules.yml
+++ b/.github/workflows/merge-jules.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   merge-palette:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.label.name == 'palette' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'palette' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -20,7 +20,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   merge-sentinel:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.label.name == 'sentinel' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'sentinel' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +32,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   merge-bolt:
       runs-on: ubuntu-latest
-      if: ${{ github.event_name == 'push' || github.event.label.name == 'bolt' }}
+      if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'bolt' }}
       steps:
         - uses: actions/checkout@v2
           with:


### PR DESCRIPTION
This PR addresses an issue where the `Merge Jules` workflow would skip all its jobs when manually triggered via `workflow_dispatch`.

The job-level `if` conditions were previously restricted to `push` events or specific pull request labels. By adding `github.event_name == 'workflow_dispatch'` to these conditions, users can now manually trigger the merge process for `palette`, `sentinel`, and `bolt` labels from the GitHub Actions tab.

Summary of changes:
- Updated `.github/workflows/merge-jules.yml` to support manual execution.
- Verified the changes by reading the modified workflow file.
- Confirmed that existing project commands (using Bun) remain unaffected.

Fixes #110

---
*PR created automatically by Jules for task [18216742939228560428](https://jules.google.com/task/18216742939228560428) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced merge workflows to support manual triggering via workflow dispatch in addition to automatic event-based execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->