### PR TITLE
🧹 Remove empty CSS rule in List component

### DIFF
--- a/src/components/List.astro
+++ b/src/components/List.astro
@@ -8,9 +8,6 @@ const { items } = Astro.props;
 	))}
 </ul>
 <style>
-	ul {
-		
-	}
 	li {
 		font-size: 0.9em;
 	}


### PR DESCRIPTION
🎯 **What:** Removed an empty CSS rule for the `ul` element in the `List.astro` component.
💡 **Why:** The empty CSS rule `ul { }` provided no styling or functionality. Removing it reduces code clutter, avoids confusion for future developers, and improves overall code cleanliness without affecting behavior.
✅ **Verification:** I manually inspected `src/components/List.astro` to ensure only the empty `ul` rule was removed and the `li` rule remained intact. I also successfully ran `bun install`, `bun test`, and `bun run build`, confirming the project still builds and runs correctly.
✨ **Result:** A cleaner component with no redundant CSS code.

---
*PR created automatically by Jules for task [9991348848239528853](https://jules.google.com/task/9991348848239528853) started by @jgeofil*