### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data exposure in analytics

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2026-03-24 - Add rel="noopener noreferrer" and sanitize URLs
-**Vulnerability:** External links created from dynamic, user-controlled data can lead to Cross-Site Scripting (XSS) via `javascript:` URIs, and missing `rel="noopener noreferrer"` causes reverse tabnabbing vulnerability.
-**Learning:** Components mapping dynamic data from `src/data/cv.json` to link attributes are required to sanitize URLs using the `sanitizeUrl` utility. External links should always use `target="_blank" rel="noopener noreferrer"`.
-**Prevention:** Implement and use a `sanitizeUrl` utility. Ensure new external link templates explicitly define `target="_blank" rel="noopener noreferrer"`.
+## 2026-03-25 - Prevent Sensitive Data Exposure in Analytics URLs
+**Vulnerability:** The web vitals reporting logic in `src/lib/vitals.js` was reading the raw `location.href` value and directly appending it to the analytics payload sent to Vercel Analytics. This raw `href` could contain sensitive information like query parameters or URL fragment hashes.
+**Learning:** Sending unsanitized URLs directly to external analytics platforms exposes Personally Identifiable Information (PII) or sensitive tokens (e.g., reset tokens, auth tokens) implicitly passed by tracking codes or backend services.
+**Prevention:** In analytics endpoints, avoid tracking `location.href` directly. Strip query parameters and hashes from the request payload by logging only `location.origin + location.pathname` to ensure strict analytics hygiene.

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -25,7 +25,8 @@ export function sendToAnalytics(metric, options) {
 		dsn: options.analyticsId,
 		id: metric.id,
 		page,
-		href: location.href,
+		// 🛡️ Sanitize URL to prevent leaking sensitive data (PII, tokens) via query parameters/hash
+		href: location.origin + location.pathname,
 		event_name: metric.name,
 		value: metric.value.toString(),
 		speed: getConnectionSpeed(),


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The web vitals reporting logic in `src/lib/vitals.js` was reading the raw `location.href` value and directly appending it to the analytics payload sent to Vercel Analytics. This raw `href` could contain sensitive information like query parameters or URL fragment hashes.
🎯 Impact: Unintentional leaking of sensitive data (PII, reset tokens, auth tokens) to external analytics platforms, compromising user privacy and account security.
🔧 Fix: Sanitized the analytics endpoint URL tracking to use `location.origin + location.pathname`, effectively stripping out any potentially sensitive query parameters or URL hashes before transmission.
✅ Verification: Ran `bun run build` and `bun test` to ensure there are no regressions. Verified locally that the payload does not contain `?token=...` styled strings.

---
*PR created automatically by Jules for task [2961298221553001306](https://jules.google.com/task/2961298221553001306) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now exclude sensitive URL query parameters and hash fragments from tracking data.

* **Chores**
  * Updated internal documentation for analytics data handling practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->