### PR TITLE
🎨 Palette: Add tooltips to icon-only links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-03-24 - Screen reader noise from decorative text elements
 **Learning:** Purely decorative text elements, such as arrow symbols (`&rarr;`) or decorative spans, are read aloud by screen readers, creating unnecessary noise for users.
 **Action:** Always add `aria-hidden="true"` to purely decorative text characters or spans (like in `Card.astro`) to ensure a cleaner and more focused screen reader experience.
+
+## 2024-05-24 - Add tooltip for icon-only links
+**Learning:** Icon-only links populated from dynamic data (like in `SocialGrid.astro`) need visual `title` tooltips in addition to `aria-label`s to improve usability for sighted users who may not recognize the icon.
+**Action:** Always add a `title` attribute matching the `aria-label` when rendering icon-only links, especially when the link text is not visually present.

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -6,7 +6,7 @@ const ICON_SIZE = 48;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer" aria-label={item.title}><!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
+		<li><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer" aria-label={item.title} title={item.title}><!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
 			<img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} /></a></li>
 	))}
 </ul>


### PR DESCRIPTION
💡 What: Added the `title` attribute to icon-only `<a>` tags in `SocialGrid.astro`, populated using `item.title` from `cv.json`.
🎯 Why: To provide sighted users with a native browser tooltip when hovering over the social icons, helping them understand what each icon represents if they don't recognize the logo visually.
📸 Before/After: Visual tooltips now appear when hovering over icons like Scholar or X.
♿ Accessibility: Sighted users benefit from visual tooltips; screen reader users continue to benefit from the existing `aria-label` which remains identical.


---
*PR created automatically by Jules for task [8599474917627712856](https://jules.google.com/task/8599474917627712856) started by @jgeofil*