### PR TITLE
Add privacy policy page with iframe and link to it in layout footer

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -107,7 +107,7 @@ const { title, description } = Astro.props as Props;
         <!-- End Google Tag Manager (noscript) -->
         <slot />
         <SpeedInsights />
-        <footer style="text-align: center; padding: 2rem 0; margin-top: 2rem; border-top: 1px solid var(--color-border); font-size: var(--font-size-sm);">
+        <footer>
             <a href="/privacy">Privacy Policy</a>
         </footer>
     </body>
@@ -163,5 +163,13 @@ const { title, description } = Astro.props as Props;
             Bitstream Vera Sans Mono,
             Courier New,
             monospace;
+    }
+
+    footer {
+        text-align: center;
+        padding: 2rem 0;
+        margin-top: 2rem;
+        border-top: 1px solid var(--color-border);
+        font-size: var(--font-size-sm);
     }
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,18 +1,24 @@
 ---
 import Layout from '../layouts/Layout.astro';
 export const prerender = true;
+const IFRAME_HEIGHT = '800px';
 ---
 
 <Layout title="Privacy Policy" description="Privacy Policy">
 	<main>
-		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" width="100%" height="800px" style="border:none;"></iframe>
+		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT}></iframe>
 	</main>
 </Layout>
 
-<style>
+<style define:vars={{ iframeHeight: IFRAME_HEIGHT }}>
 	main {
 		margin: auto;
 		padding: 1em;
 		max-width: 60ch;
+	}
+	iframe {
+		width: 100%;
+		height: var(--iframeHeight);
+		border: none;
 	}
 </style>


### PR DESCRIPTION
Add privacy policy page with iframe and link to it in layout footer

---
*PR created automatically by Jules for task [17289167076694463811](https://jules.google.com/task/17289167076694463811) started by @jgeofil*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Privacy Policy page with embedded documentation for user reference
  * Added a footer section across all pages with convenient navigation to the Privacy Policy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->