### PR TITLE
Persist combined merge commit in GitHub Actions workflow

### DIFF
--- a/.github/workflows/merge-jules.yml
+++ b/.github/workflows/merge-jules.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           label: palette
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push combined changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git push origin main
   merge-sentinel:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'sentinel' }}
@@ -30,6 +35,11 @@ jobs:
         with:
           label: sentinel
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push combined changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git push origin main
   merge-bolt:
       runs-on: ubuntu-latest
       if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.label.name == 'bolt' }}
@@ -42,3 +52,8 @@ jobs:
           with:
             label: bolt
             repo-token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Push combined changes
+          run: |
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git push origin main


### PR DESCRIPTION
I have updated the `.github/workflows/merge-jules.yml` file to ensure that combined merge commits are pushed back to the `main` branch. Previously, the `combine-pull-requests` action created a local merge commit that was never persisted. Now, a "Push combined changes" step has been added to each job (`merge-palette`, `merge-sentinel`, and `merge-bolt`) to configure the Git user and push the changes to `main`.

Fixes #111

---
*PR created automatically by Jules for task [10698037138372754819](https://jules.google.com/task/10698037138372754819) started by @jgeofil*