### PR TITLE
Fix Astro build failure in middleware resolution

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,4 +1,4 @@
-/// <reference types="astro/client-image" />
+/// <reference types="astro/client" />
 
 interface ImportMetaEnv {
 	readonly PUBLIC_VERCEL_ANALYTICS_ID: string;


### PR DESCRIPTION
The build failed on Vercel because Vite/Rollup could not resolve the virtual module `astro:middleware`. This is a known issue when migrating Astro projects to versions 3.x and above if the manual step of updating `src/env.d.ts` is skipped. The previous reference to `astro/client-image` was deprecated and replaced by the unified `astro/client` types. This update fixes the module resolution by providing the correct environment type definitions to the Astro compiler and Vite.

Fixes #39

---
*PR created automatically by Jules for task [495571415192344565](https://jules.google.com/task/495571415192344565) started by @jgeofil*