### PR TITLE
🎨 Palette: Hide decorative text separators from screen readers

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -19,8 +19,8 @@ export const prerender = true;
 		
 		<p>
 			<a href="mailto:jeremygeo@gmail.com">jeremygeo@gmail.com</a>
-			 | <a href="tel:+15818491348">581-849-1348</a>
-			 | <a href="https://jeremygf.com">jeremygf.com</a>
+			 <span aria-hidden="true">|</span> <a href="tel:+15818491348">581-849-1348</a>
+			 <span aria-hidden="true">|</span> <a href="https://jeremygf.com">jeremygf.com</a>
 		</p>
 		<em>Machine Learning Engineer, Computational Biologist</em>
 		<p>


### PR DESCRIPTION
🎨 Palette: Hide decorative text separators from screen readers

💡 **What:** Added `aria-hidden="true"` to the pipe (`|`) text separators in the header of `src/pages/cv.astro`.
🎯 **Why:** Screen readers read out purely decorative text elements like "vertical line" or "bar", which creates unnecessary auditory noise and disrupts the reading flow of the contact information (email, phone, website).
📸 **Before/After:** No visual changes, but a significantly improved experience for screen reader users.
♿ **Accessibility:** This directly addresses the UX/A11y learning from the Palette journal regarding decorative text noise.

---
*PR created automatically by Jules for task [11944379178497265437](https://jules.google.com/task/11944379178497265437) started by @jgeofil*