### PR TITLE
🔒 Prevent sensitive data exposure in Vercel analytics

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Sensitive Data Exposure via Full URL Tracking
+**Vulnerability:** The Vercel analytics tracking logic in `src/lib/vitals.js` was capturing the full `location.href`, which included sensitive query parameters (e.g., API tokens, session IDs) and URL fragments.
+**Learning:** Using `location.href` for analytics tracking is dangerous as it can inadvertently leak sensitive information contained in the URL to third-party analytics services or log them in backend systems.
+**Prevention:** Always sanitize URLs before sending them to analytics by stripping query parameters and hashes. Use `location.origin + location.pathname` to capture only the base URL path.

--- a/src/lib/vitals.js
+++ b/src/lib/vitals.js
@@ -25,7 +25,7 @@ export function sendToAnalytics(metric, options) {
 		dsn: options.analyticsId,
 		id: metric.id,
 		page,
-		href: location.href,
+		href: location.origin + location.pathname,
 		event_name: metric.name,
 		value: metric.value.toString(),
 		speed: getConnectionSpeed(),


### PR DESCRIPTION
### 🎯 What
The vulnerability fixed is sensitive data exposure via full URL tracking in Vercel analytics.

### ⚠️ Risk
If left unfixed, sensitive information such as API tokens, session IDs, or PII contained in URL query parameters or hashes could be leaked to the analytics provider and potentially exposed in logs or dashboards.

### 🛡️ Solution
The fix involves sanitizing the `href` field in the analytics payload by using `location.origin + location.pathname` instead of `location.href`. This ensures only the base URL and path are tracked, stripping away any sensitive parameters or fragments.

---
*PR created automatically by Jules for task [14519509849199556981](https://jules.google.com/task/14519509849199556981) started by @jgeofil*