### PR TITLE
🔒 [security fix] Add rel="noopener noreferrer" to external links

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -9,7 +9,7 @@ const { href, title, body } = Astro.props as Props;
 ---
 
 <li class="link-card">
-	<a href={href}>
+	<a href={href} rel="noopener noreferrer">
 		<h2>
 			{title}
 			<span>&rarr;</span>

--- a/src/components/Funding.astro
+++ b/src/components/Funding.astro
@@ -4,7 +4,7 @@ const { row } = Astro.props;
 
 <tr>
 	<td class="date-col">{row.date}</td>
-	<td><b>{row.title}</b> <a href={row.url}>{row.description}</a></td>
+	<td><b>{row.title}</b> <a href={row.url} rel="noopener noreferrer">{row.description}</a></td>
 </tr>
 <style>
 	table {

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url}>{item.title}</a></li>  
+		<li><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} /><a href={item.url} rel="noopener noreferrer">{item.title}</a></li>
 	))}
 </ul>
 <style>

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -4,7 +4,7 @@ const { row } = Astro.props;
 
 <tr>
 	<td class="date-col">{row.date}</td>
-	<td><a href={row.url}><b>{row.title}</b></a> {row.description}</td>
+	<td><a href={row.url} rel="noopener noreferrer"><b>{row.title}</b></a> {row.description}</td>
 </tr>
 <style>
 	table {

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url} rel="noopener noreferrer"><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
 	))}
 </ul>
 <style>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -20,7 +20,7 @@ export const prerender = true;
 		<p>
 			<a href="mailto:jeremygeo@gmail.com">jeremygeo@gmail.com</a>
 			 | <a href="tel:+15818491348">581-849-1348</a>
-			 | <a href="https://jeremygf.com">jeremygf.com</a>
+			 | <a href="https://jeremygf.com" rel="noopener noreferrer">jeremygf.com</a>
 		</p>
 		<em>Machine Learning Engineer, Computational Biologist</em>
 		<p>


### PR DESCRIPTION
This pull request addresses a security vulnerability where external links were missing the `rel="noopener noreferrer"` attribute. This attribute is crucial for preventing "tabnabbing," where a malicious page linked from the site could potentially gain control over the original tab. It also enhances user privacy by preventing the browser from sending the `Referer` header to the destination site.

The fix was applied comprehensively across the following files:
- `src/components/Card.astro`
- `src/components/LinkGrid.astro`
- `src/components/Project.astro`
- `src/components/SocialGrid.astro`
- `src/components/Funding.astro`
- `src/pages/cv.astro`

Verified the changes using `grep` to ensure all relevant `<a>` tags were updated. All identified external links now include the security attribute. Internal and special protocol links (e.g., `mailto:`, `tel:`) were not modified as they are not susceptible to this specific vulnerability.

---
*PR created automatically by Jules for task [17376037529773075576](https://jules.google.com/task/17376037529773075576) started by @jgeofil*