### PR TITLE
⚡ Add lazy loading and dimensions to SocialGrid images

### DIFF
--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -4,7 +4,7 @@ const { items } = Astro.props;
 
 <ul class="list-grid">
 	{items.map((item, index) => (
-		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} /></a></li>
+		<li><a href={item.url}><img src={item.icon_url ? item.icon_url : `https://cdn.simpleicons.org/${item.icon}/${item.color}`} loading="lazy" width="48" height="48" alt={item.icon || 'social icon'} /></a></li>
 	))}
 </ul>
 <style>


### PR DESCRIPTION
💡 **What:** Added `loading="lazy"`, `width="48"`, `height="48"`, and `alt` attributes to the `<img>` tag in `src/components/SocialGrid.astro`.
🎯 **Why:** To improve initial page load performance by deferring the loading of off-screen images and to prevent Cumulative Layout Shift (CLS) by specifying image dimensions. Added `alt` text for better accessibility.
📊 **Measured Improvement:** I was unable to establish a quantitative baseline due to environment setup issues in the sandbox (Astro build/dev server could not be started). However, lazy loading is a well-established performance best practice that reduces initial payload and network contention. Specifying `width` and `height` directly addresses CLS, a key Core Web Vital.

---
*PR created automatically by Jules for task [1896968685737225010](https://jules.google.com/task/1896968685737225010) started by @jgeofil*