### PR TITLE
🧹 Remove empty style block in List.astro

### DIFF
--- a/src/components/List.astro
+++ b/src/components/List.astro
@@ -8,9 +8,6 @@ const { items } = Astro.props;
 	))}
 </ul>
 <style>
-	ul {
-		
-	}
 	li {
 		font-size: 0.9em;
 	}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
- Removed an empty `ul` CSS rule in `src/components/List.astro`.

💡 **Why:** How this improves maintainability
- Removing dead code improves the readability and maintainability of the stylesheet by eliminating unnecessary blocks.

✅ **Verification:** How you confirmed the change is safe
- Verified by reading the file content after the edit to ensure only the empty block was removed.
- The change is a zero-risk CSS cleanup in a scoped Astro component.

✨ **Result:** The improvement achieved
- A cleaner and more concise `List.astro` component.

---
*PR created automatically by Jules for task [15040689094307135921](https://jules.google.com/task/15040689094307135921) started by @jgeofil*