### PR TITLE
🧪 [testing improvement] Add error handling test for webVitals

### DIFF
--- a/src/lib/vitals.test.js
+++ b/src/lib/vitals.test.js
@@ -1,0 +1,49 @@
+import { test, expect, mock, spyOn, beforeEach } from "bun:test";
+
+// Mock the web-vitals module before importing the module that uses it
+mock.module("web-vitals", () => {
+	return {
+		onFID: mock((cb) => {}),
+		onTTFB: mock((cb) => {}),
+		onLCP: mock((cb) => {}),
+		onCLS: mock((cb) => {}),
+		onFCP: mock((cb) => {}),
+	};
+});
+
+// Now import webVitals and the mocked module
+import { webVitals } from "./vitals.js";
+import * as webVitalsModule from "web-vitals";
+
+test("webVitals logs error when a web-vitals function throws", () => {
+	const error = new Error("Test error");
+	webVitalsModule.onFID.mockImplementationOnce(() => {
+		throw error;
+	});
+
+	const consoleSpy = spyOn(console, "error").mockImplementation(() => {});
+
+	webVitals({});
+
+	expect(consoleSpy).toHaveBeenCalledWith("[Web Vitals]", error);
+
+	consoleSpy.mockRestore();
+});
+
+test("webVitals registers all callbacks in happy path", () => {
+	// Reset mocks manually since restore_all might not be available as expected
+	webVitalsModule.onFID.mockClear();
+	webVitalsModule.onTTFB.mockClear();
+	webVitalsModule.onLCP.mockClear();
+	webVitalsModule.onCLS.mockClear();
+	webVitalsModule.onFCP.mockClear();
+
+	const options = { some: "options" };
+	webVitals(options);
+
+	expect(webVitalsModule.onFID).toHaveBeenCalled();
+	expect(webVitalsModule.onTTFB).toHaveBeenCalled();
+	expect(webVitalsModule.onLCP).toHaveBeenCalled();
+	expect(webVitalsModule.onCLS).toHaveBeenCalled();
+	expect(webVitalsModule.onFCP).toHaveBeenCalled();
+});


### PR DESCRIPTION
This PR addresses the missing error test in the `webVitals` catch block in `src/lib/vitals.js`.

### 🎯 What
The testing gap addressed is the lack of verification for the error handling logic in the `webVitals` function.

### 📊 Coverage
The following scenarios are now tested in `src/lib/vitals.test.js`:
- **Error Handling**: Mocks a `web-vitals` function to throw an error and asserts that `console.error` is called with the expected prefix and error object.
- **Happy Path**: Verifies that `webVitals` correctly registers all callbacks (`onFID`, `onTTFB`, `onLCP`, `onCLS`, `onFCP`) when no error occurs.

### ✨ Result
Improved test coverage and reliability for the web vitals integration, ensuring that errors are correctly caught and logged.

---
*PR created automatically by Jules for task [7524994215214939232](https://jules.google.com/task/7524994215214939232) started by @jgeofil*