### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard accessibility

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -99,6 +99,7 @@ const { title, description } = Astro.props as Props;
         </script>
     </head>
     <body>
+        <a href="#main-content" class="skip-to-content">Skip to content</a>
         <!-- Google Tag Manager (noscript) -->
         <noscript
             ><iframe
@@ -186,5 +187,31 @@ const { title, description } = Astro.props as Props;
         margin-top: 2rem;
         border-top: 1px solid var(--color-border);
         font-size: var(--font-size-sm);
+    }
+
+    .skip-to-content {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
+    }
+
+    .skip-to-content:focus {
+        position: static;
+        width: auto;
+        height: auto;
+        padding: 1rem;
+        margin: 0;
+        overflow: visible;
+        clip: auto;
+        white-space: normal;
+        background-color: var(--color-bg);
+        color: var(--color-text);
+        z-index: 999;
     }
 </style>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -14,7 +14,7 @@ export const prerender = true;
 ---
 
 <Layout title="Jeremy Georges-Filteau - CV" description='You can find my CV here.'>
-	<main>
+	<main id="main-content">
 		<h1>Jeremy Georges-Filteau</h1>
 		
 		<p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ export const prerender = true;
 ---
 
 <Layout title="Jeremy Georges-Filteau - About me" description='Learn more about me.'>
-	<main>
+	<main id="main-content">
 		<div>
 			<!-- Optimize: Use Astro's Image component with local assets. This allows Astro to automatically optimize the image (resizing, converting to WebP/AVIF, etc.) during the build process, reducing the final bundle size, improving LCP and page load times. Explicit width and height prevent Cumulative Layout Shift (CLS). -->
 			<Image class="profile-img" src={profileImage} alt="Jeremy Georges-Filteau" width="200" height="200" loading="eager" />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -5,7 +5,7 @@ const IFRAME_HEIGHT = '800px';
 ---
 
 <Layout title="Privacy Policy" description="Privacy Policy">
-	<main>
+	<main id="main-content">
 		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT}></iframe>
 	</main>
 </Layout>


### PR DESCRIPTION
💡 **What**: Added a "Skip to content" link as the first focusable element on the page. Added `id="main-content"` to the `<main>` tags on the `index.astro`, `cv.astro`, and `privacy.astro` pages.
🎯 **Why**: To improve keyboard navigation by allowing screen reader and keyboard-only users to bypass repetitive navigation links and jump directly to the main content.
📸 **Before/After**: N/A (Visually hidden until focused)
♿ **Accessibility**: Significant improvement for keyboard navigation and screen reader users, adhering to WCAG guidelines for bypassing blocks.

---
*PR created automatically by Jules for task [10138003252529806264](https://jules.google.com/task/10138003252529806264) started by @jgeofil*