### PR TITLE
🛡️ Sentinel: Add sandbox attribute to external iframe

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `<Card />` Astro component accepted an `href` prop and outputted it directly into an anchor tag without sanitization. This allowed the potential for Cross-Site Scripting (XSS) if malicious URLs (like `javascript:alert(1)`) were passed to the component.
 **Learning:** Even static components that render links from props can be vectors for XSS if those props can be controlled by external data or unsanitized user input in the future.
 **Prevention:** Always sanitize URLs using a robust utility (e.g., `sanitizeUrl` to strip dangerous protocols like `javascript:`, `data:`, etc.) before rendering them into `href` attributes in UI components.
+
+## 2026-04-15 - Sandbox External Iframes
+**Vulnerability:** The iframe embedding a Google Doc in `src/pages/privacy.astro` lacked a `sandbox` attribute, potentially allowing the embedded content to execute malicious scripts or navigate the top-level browsing context.
+**Learning:** Iframes embedding external content must use the `sandbox` attribute to minimize security risks.
+**Prevention:** Always add a `sandbox` attribute (e.g., `sandbox="allow-scripts allow-same-origin"`) to `<iframe>` elements loading external resources.

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,7 +6,7 @@ const IFRAME_HEIGHT = '800px';
 
 <Layout title="Privacy Policy" description="Privacy Policy">
 	<main>
-		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT}></iframe>
+		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT} sandbox="allow-scripts allow-same-origin"></iframe>
 	</main>
 </Layout>
 


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The iframe embedding a Google Doc in privacy.astro lacked a sandbox attribute.
🎯 Impact: Without sandboxing, the embedded content could potentially execute malicious scripts or navigate the top-level browsing context if the external site is compromised.
🔧 Fix: Added sandbox="allow-scripts allow-same-origin" to the iframe to minimize security risks.
✅ Verification: The application builds successfully and the iframe renders correctly.

---
*PR created automatically by Jules for task [7967374500989585581](https://jules.google.com/task/7967374500989585581) started by @jgeofil*