### PR TITLE
🎨 Palette: Add role='list' to restore list semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,7 @@
 ## 2024-05-24 - Screen reader context for repeated link text
 **Learning:** Using data fields like `item.title` for `aria-label` on social links fails when the title is identical across multiple platforms (e.g., "jgeofil" for GitHub, LinkedIn, and Twitter). Sighted users rely on the visual icons, but screen readers only hear the repeated title.
 **Action:** Always include the platform or icon name in the accessible text (e.g., `<span class="sr-only">GitHub: </span>`) to provide necessary context for screen reader users when visual icons are hidden.
+
+## 2024-05-24 - Safari VoiceOver list semantics bug
+**Learning:** Safari and VoiceOver remove list semantics from `<ul>` elements when `list-style: none` is applied. This prevents screen reader users from accessing list navigation features (like item counts).
+**Action:** Always explicitly add `role="list"` to `<ul>` or `<ol>` elements when using `list-style: none` to ensure list semantics are preserved for all screen readers.

--- a/src/components/Grid.astro
+++ b/src/components/Grid.astro
@@ -2,7 +2,7 @@
 const { items } = Astro.props;
 ---
 
-<ul class="list-grid">
+<ul role="list" class="list-grid">
 	{items.map((item, index) => (
 		<li>{item}</li>  
 	))}

--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -11,7 +11,7 @@ const ICON_SIZE = 16;
 // saving memory allocations and speeding up list rendering.
 ---
 
-<ul class="list-grid">
+<ul role="list" class="list-grid">
 	{items.map((item, index) => (
 		<li><!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
 			<img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} /><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer"><span class="sr-only">{formatPlatform(item.icon)}: </span>{item.title}<span class="sr-only"> (opens in a new tab)</span></a></li>

--- a/src/components/SocialGrid.astro
+++ b/src/components/SocialGrid.astro
@@ -11,7 +11,7 @@ const ICON_SIZE = 48;
 // saving memory allocations and speeding up list rendering.
 ---
 
-<ul class="list-grid">
+<ul role="list" class="list-grid">
 	{items.map((item, index) => (
 		<li><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer" title={`${formatPlatform(item.icon)}: ${item.title}`}>
 			<span class="sr-only">{formatPlatform(item.icon)}: {item.title} (opens in a new tab)</span>


### PR DESCRIPTION
💡 What: Added `role="list"` to `<ul>` elements in Grid, LinkGrid, and SocialGrid components.
🎯 Why: Safari and VoiceOver remove list semantics when `list-style: none` is applied, breaking screen reader navigation. Adding the explicit role restores this functionality.
📸 Before/After: N/A - visual appearance remains unchanged.
♻️ Accessibility: Screen reader users can now properly navigate and understand list structures across the site.