### PR TITLE
🔒 Add Content-Security-Policy header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** The `sanitizeUrl` function in `src/lib/security.js` was removing control characters and checking for obfuscated protocols using `&colon;`, but it didn't decode generic hexadecimal and decimal HTML entities. Attackers could bypass XSS protections using encoded protocols like `&#x6A;avascript:alert(1)`.
 **Learning:** Browsers often decode HTML entities within attributes like `href` or `src` before interpreting the URI protocol. Therefore, any URL sanitization logic must properly decode these entities prior to validating the scheme.
 **Prevention:** Ensure URL validation decodes standard HTML entities (hexadecimal, decimal, and named) before checking against a blocklist of dangerous protocols.
+
+## 2024-05-20 - Added Content-Security-Policy header
+**Vulnerability:** Missing Content-Security-Policy (CSP) Header in vercel.json.
+**Learning:** A basic CSP header mitigates XSS risks and is a straightforward configuration improvement.
+**Prevention:** Ensure CSP is configured in the web server settings by default.

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
       "source": "/(.*)",
       "headers": [
         {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';"
+        },
+        {
           "key": "X-Content-Type-Options",
           "value": "nosniff"
         },

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https:; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://vitals.vercel-analytics.com; frame-src 'self' https://docs.google.com; object-src 'none'; base-uri 'self'; form-action 'self';"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
🎯 **What:** The `vercel.json` configuration was missing a Content-Security-Policy (CSP) header.

⚠️ **Risk:** Without a CSP, the application is more vulnerable to Cross-Site Scripting (XSS) attacks, as browsers will execute inline scripts and load resources from any origin by default.

🛡️ **Solution:** Added a strict `Content-Security-Policy` header to `vercel.json` that sets sensible defaults (allowing scripts/styles from `self`, `unsafe-inline`, and HTTPS, while blocking `object-src`).