### PR TITLE
🧹 Code Health: Improve dynamic imports for Statsig

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -65,9 +65,9 @@ const { title, description } = Astro.props as Props;
                         import("@statsig/session-replay"),
                         import("@statsig/web-analytics")
                     ]).then(([
-                        { StatsigClient },
-                        { StatsigSessionReplayPlugin },
-                        { StatsigAutoCapturePlugin }
+                        { default: { StatsigClient } },
+                        { default: { StatsigSessionReplayPlugin } },
+                        { default: { StatsigAutoCapturePlugin } }
                     ]) => {
                         const statsig = new StatsigClient(
                             statsigKey,


### PR DESCRIPTION
🎯 **What:** Modified dynamic imports for `@statsig` modules to properly destructure their default exports instead of their module namespaces.
💡 **Why:** As noted in the codebase rules and to ensure full compatibility with standard ESM compilation targets, the dynamic `import()` function resolves to a module namespace object. For modules that provide their primary API via a `default` export, standard destructuring requires extracting the properties from the `default` object rather than the namespace itself.
✅ **Verification:** Ran `bun test` and `bun run build` successfully to confirm no breakage.
✨ **Result:** Ensures robustness and standards-compliant code-splitting during the build process, reducing potential for runtime module resolution errors.