### PR TITLE
🧹 [code health] remove stale optimize comments for dynamic imports

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-24 - Defer third-party scripts to improve Total Blocking Time (TBT)
 **Learning:** Third-party analytics scripts like PostHog, Statsig, and Vercel Analytics can significantly impact initial load performance and increase Total Blocking Time (TBT) if loaded and executed immediately on the main thread.
 **Action:** Wrap the dynamic import and initialization logic for these third-party scripts in `requestIdleCallback` (with a `setTimeout` fallback). Also, use `<link rel="preconnect" href="<API_HOST>" />` in the `<head>` to reduce network connection latency.
+
+## 2026-05-20 - Remove Stale Comments
+**Learning:** Outdated or completed "Optimize:" comments can clutter the codebase and reduce maintainability.
+**Action:** When working on code health, ensure comments accurately reflect the current state of the code and remove those that point to optimizations already implemented.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -44,7 +44,6 @@ const { title, description } = Astro.props as Props;
 
             const initAnalytics = () => {
                 if (analyticsId) {
-                    // Optimize: Use dynamic import for webVitals to prevent render blocking
                     import("../lib/vitals.js")
                         .then(({ webVitals }) => {
                             webVitals({
@@ -59,7 +58,6 @@ const { title, description } = Astro.props as Props;
                 }
 
                 if (statsigKey) {
-                    // Optimize: Use dynamic imports for Statsig to enable code splitting and reduce initial client payload size
                     Promise.all([
                         import("@statsig/js-client"),
                         import("@statsig/session-replay"),
@@ -86,7 +84,6 @@ const { title, description } = Astro.props as Props;
                 }
 
                 if (posthogKey) {
-                    // Optimize: Use dynamic import for PostHog to enable code splitting and reduce initial client payload size
                     import("posthog-js")
                         .then((posthog) => {
                             posthog.default.init(posthogKey, {


### PR DESCRIPTION
🎯 **What:** Removed stale code health comments suggesting dynamic imports for webVitals, Statsig, and PostHog.
💡 **Why:** The dynamic import optimizations have already been implemented. The comments are now redundant and removing them improves codebase readability and maintainability.
✅ **Verification:** Verified that the code runs successfully with `bun run build` and tests pass with `bun test`.
✨ **Result:** Codebase is cleaner and free of outdated instructions.