### PR TITLE
🎨 Palette: Improve LinkGrid accessibility and clickable area

### DIFF
--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -13,8 +13,13 @@ const ICON_SIZE = 16;
 
 <ul role="list" class="list-grid">
 	{items.map((item, index) => (
-		<li><!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
-			<img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} /><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer"><span class="sr-only">{formatPlatform(item.icon)}: </span>{item.title}<span class="sr-only"> (opens in a new tab)</span></a></li>
+		<li>
+			<a class="link-item" href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer">
+				<!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
+				<img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} />
+				<span class="sr-only">{formatPlatform(item.icon)}: </span>{item.title}<span class="sr-only"> (opens in a new tab)</span>
+			</a>
+		</li>
 	))}
 </ul>
 <style define:vars={{ iconSize: `${ICON_SIZE}px` }}>
@@ -35,5 +40,10 @@ const ICON_SIZE = 16;
 		width: var(--iconSize);
 		height: var(--iconSize);
 		margin-right: 0.5em;
+	}
+
+	.link-item {
+		display: inline-flex;
+		align-items: center;
 	}
 </style>


### PR DESCRIPTION
💡 What: Wrapped the visual icon (`<img>`) inside the adjacent `<a>` anchor tag in `LinkGrid.astro` and aligned them using flexbox.

🎯 Why: The previous implementation placed the image adjacent to the link. This created a "dead click" zone where clicking the icon itself wouldn't trigger the link. It also meant the keyboard focus ring only highlighted the text, not the icon.

📸 Before/After: Visual alignment remains identical, but the interactive area is now unified.

♿ Accessibility: Ensures that the entire visual representation of the link (both icon and text) acts as a single interactive element, providing a larger, continuous touch target and a cohesive focus state for keyboard users.
