### PR TITLE
⚡ Bolt: Remove duplicate CSS from table components

### DIFF
--- a/src/components/DatedRow.astro
+++ b/src/components/DatedRow.astro
@@ -15,18 +15,3 @@ const { row } = Astro.props;
 		</List>
 		</td>
 </tr>
-<style>
-	table {
-		width: 100%;
-		table-layout: fixed;
-	}
-
-	td {
-		padding-right: 0.5em;
-		vertical-align: top;
-	}
-
-	.date-col {
-		width: 15%;
-	}
-</style>

--- a/src/components/Funding.astro
+++ b/src/components/Funding.astro
@@ -7,18 +7,3 @@ const { row } = Astro.props;
 	<td class="date-col">{row.date}</td>
 	<td><b>{row.title}</b> <a href={sanitizeUrl(row.url)} target="_blank" rel="noopener noreferrer">{row.description}<span class="sr-only"> (opens in a new tab)</span></a></td>
 </tr>
-<style>
-	table {
-		width: 100%;
-		table-layout: fixed;
-	}
-
-	td {
-		padding-right: 0.5em;
-		vertical-align: top;
-	}
-
-	.date-col {
-		width: 15%;
-	}
-</style>

--- a/src/components/Project.astro
+++ b/src/components/Project.astro
@@ -7,18 +7,3 @@ const { row } = Astro.props;
 	<td class="date-col">{row.date}</td>
 	<td><a href={sanitizeUrl(row.url)} target="_blank" rel="noopener noreferrer"><b>{row.title}</b><span class="sr-only"> (opens in a new tab)</span></a> {row.description}</td>
 </tr>
-<style>
-	table {
-		width: 100%;
-		table-layout: fixed;
-	}
-
-	td {
-		padding-right: 0.5em;
-		vertical-align: top;
-	}
-
-	.date-col {
-		width: 15%;
-	}
-</style>

--- a/src/components/Publication.astro
+++ b/src/components/Publication.astro
@@ -6,18 +6,3 @@ const { row } = Astro.props;
 	<td class="date-col">{row.date}</td>
 	<td>{row.authors}, <b>{row.title}</b>, {row.journal}</td>
 </tr>
-<style>
-	table {
-		width: 100%;
-		table-layout: fixed;
-	}
-
-	td {
-		padding-right: 0.5em;
-		vertical-align: top;
-	}
-
-	.date-col {
-		width: 15%;
-	}
-</style>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -114,4 +114,17 @@ export const prerender = true;
 		font-size: 1.5em;
 	}
 
+	table {
+		width: 100%;
+		table-layout: fixed;
+	}
+
+	table :global(td) {
+		padding-right: 0.5em;
+		vertical-align: top;
+	}
+
+	table :global(.date-col) {
+		width: 15%;
+	}
 </style>


### PR DESCRIPTION
💡 What: Removed duplicate `<style>` blocks for tables from `DatedRow.astro`, `Funding.astro`, `Project.astro`, and `Publication.astro`, and consolidated them in the parent page `cv.astro` using the `:global` modifier.

🎯 Why: To reduce the CSS payload size and avoid sending identical styles multiple times to the client.

📊 Impact: Reduces the size of the generated HTML/CSS by eliminating duplicate class declarations. This also improves maintainability.

🔬 Measurement: Run `bun run build` and inspect the generated HTML for `cv/index.html`. You can confirm that the table styles are included only once in the `<style>` block at the top, rather than duplicated for each table component.
