### PR TITLE
🎨 Palette: Wrap link icons in anchor tags

### DIFF
--- a/src/components/LinkGrid.astro
+++ b/src/components/LinkGrid.astro
@@ -14,7 +14,7 @@ const ICON_SIZE = 16;
 <ul role="list" class="list-grid">
 	{items.map((item, index) => (
 		<li><!-- Optimize: lazy loading images improves LCP. Explicit width/height prevents Cumulative Layout Shift (CLS) -->
-			<img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} /><a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer"><span class="sr-only">{formatPlatform(item.icon)}: </span>{item.title}<span class="sr-only"> (opens in a new tab)</span></a></li>
+			<a href={sanitizeUrl(item.url)} target="_blank" rel="noopener noreferrer"><img src={`https://cdn.simpleicons.org/${item.icon}/${item.color}`} alt="" aria-hidden="true" loading="lazy" width={ICON_SIZE} height={ICON_SIZE} /><span class="sr-only">{formatPlatform(item.icon)}: </span>{item.title}<span class="sr-only"> (opens in a new tab)</span></a></li>
 	))}
 </ul>
 <style define:vars={{ iconSize: `${ICON_SIZE}px` }}>
@@ -29,6 +29,11 @@ const ICON_SIZE = 16;
 		grid-template-columns: repeat(auto-fit, minmax(24ch, 1fr));
 
 		padding: 0;
+	}
+
+	a {
+		display: inline-flex;
+		align-items: center;
 	}
 
 	img {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -92,6 +92,9 @@ const { title, description } = Astro.props as Props;
                             posthog.register({
                                 date: '2026-01-30'
                             });
+                                api_host: 'https://t.mlread.me',
+                                defaults: '2026-01-30'
+                            });
                         })
                         .catch((err) => {
                             console.error("[PostHog] dynamic import failed", err);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -92,9 +92,6 @@ const { title, description } = Astro.props as Props;
                             posthog.register({
                                 date: '2026-01-30'
                             });
-                                api_host: 'https://t.mlread.me',
-                                defaults: '2026-01-30'
-                            });
                         })
                         .catch((err) => {
                             console.error("[PostHog] dynamic import failed", err);


### PR DESCRIPTION
💡 What: The companion visual icon `<img>` inside `LinkGrid.astro` was moved inside its respective `<a>` tag.
🎯 Why: Icons adjacent to text links often lead to dead clicks when a user attempts to interact directly with the icon. By wrapping both the text and the icon in the `<a>` tag, the interactive area covers both.
📸 Before/After: Before, focus rings were missing or non-uniform, and clicking the icon did not execute the link. After, there is a single focus ring encompassing both, and clicking the icon opens the link.
♿ Accessibility: Screen reader users tab directly to the text link and now only hear one cohesive element, instead of an adjacent unclickable element.