### PR TITLE
⚡ Bolt: Preconnect to Google Tag Manager

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,8 @@ const { title, description } = Astro.props as Props;
 <!doctype html>
 <html lang="en">
     <head>
+        <!-- Optimize: Early preconnect to GTM domain to reduce DNS, TCP, and TLS latency, improving script load time. -->
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
         <!-- Google Tag Manager -->
         <script is:inline>
             (function (w, d, s, l, i) {


### PR DESCRIPTION
💡 What: Added `<link rel="preconnect" href="https://www.googletagmanager.com" />` to the global `<head>` in `Layout.astro`.

🎯 Why: The application explicitly loads Google Tag Manager scripts as early as possible. Preconnecting to the Google Tag Manager domain allows the browser to initiate the DNS resolution, TCP handshake, and TLS negotiation early, significantly reducing the latency associated with downloading `gtm.js`.

📊 Impact: Faster time to initialize analytics tools due to reduced network latency when downloading the GTM payload.

🔬 Measurement: Inspect Network tab in DevTools (specifically connection start timings for `gtm.js`) or measure the time to execute GTM initialization in Performance traces.