### PR TITLE
🎨 Palette: Fix undefined text color variable in Card component

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -40,7 +40,7 @@ const { href, title, body } = Astro.props as Props;
 		line-height: 1.4;
 		padding: 1em 1.3em;
 		border-radius: 0.35rem;
-		color: var(--text-color);
+		color: var(--color-text);
 		background-color: white;
 		opacity: 0.8;
 	}


### PR DESCRIPTION
💡 What: Fixed an incorrect CSS variable reference (`--text-color` to `--color-text`) in `Card.astro`.

🎯 Why: The card text was not properly inheriting the global text color theme due to a typo in the CSS variable name, potentially causing subtle readability or visual consistency issues.

📸 Before/After: Code change only (ensures correct styling inheritance).

♿ Accessibility: Ensures text color matches the intended theme for reliable contrast.