### PR TITLE
🎨 Palette: Add accessibility attributes and hide decorative elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -17,3 +17,7 @@
 ## 2024-05-24 - Safari VoiceOver list semantics bug
 **Learning:** Safari and VoiceOver remove list semantics from `<ul>` elements when `list-style: none` is applied. This prevents screen reader users from accessing list navigation features (like item counts).
 **Action:** Always explicitly add `role="list"` to `<ul>` or `<ol>` elements when using `list-style: none` to ensure list semantics are preserved for all screen readers.
+
+## 2026-06-24 - Screen reader noise from layout tables and decorative characters
+**Learning:** Using `<table>` elements purely for structural layout (like aligning dates next to descriptions) causes screen readers to announce them as data tables, creating unnecessary noise. Furthermore, decorative text characters (like `|` separators) are read aloud individually.
+**Action:** Always add `role="presentation"` to layout tables, and wrap purely decorative text characters in `<span aria-hidden="true">` to significantly improve the screen reader experience.

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -19,8 +19,8 @@ export const prerender = true;
 		
 		<p>
 			<a href="mailto:jeremygeo@gmail.com">jeremygeo@gmail.com</a>
-			 | <a href="tel:+15818491348">581-849-1348</a>
-			 | <a href="https://jeremygf.com">jeremygf.com</a>
+			 <span aria-hidden="true">|</span> <a href="tel:+15818491348">581-849-1348</a>
+			 <span aria-hidden="true">|</span> <a href="https://jeremygf.com">jeremygf.com</a>
 		</p>
 		<em>Machine Learning Engineer, Computational Biologist</em>
 		<p>
@@ -33,7 +33,7 @@ export const prerender = true;
 		<Grid items={cvData.skills} />
 		
 		<h2>Experience</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.experience.map((job) => (
 					<DatedRow row={job} />
@@ -43,7 +43,7 @@ export const prerender = true;
 
 		<h2>Projects</h2>
 
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.projects.map((project) => (
 				<Project row={project} />
@@ -52,7 +52,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Certificates</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.certificates.map((certificate) => (
 					<Project row={certificate} />
@@ -61,7 +61,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Education</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.education.map((school) => (
 					<DatedRow row={school} />
@@ -72,7 +72,7 @@ export const prerender = true;
 		
 
 		<h2>Publications</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.publications.map((publication) => (
 				<Publication row={publication} />
@@ -81,7 +81,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Grants</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.grants.map((funding) => (
 				<Funding row={funding} />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -6,7 +6,7 @@ const IFRAME_HEIGHT = '800px';
 
 <Layout title="Privacy Policy" description="Privacy Policy">
 	<main>
-		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT} sandbox="allow-scripts allow-same-origin"></iframe>
+		<iframe src="https://docs.google.com/document/d/e/2PACX-1vS_xYTgSEvcNVvb7NH6yYZ4GeAwKrQm4nMp4YY3z58Ozl3OEl6_XGT1fp3mcRCyqONCHoy7ITmuk9DZ/pub?embedded=true" height={IFRAME_HEIGHT} sandbox="allow-scripts allow-same-origin" title="Privacy Policy Document"></iframe>
 	</main>
 </Layout>
 


### PR DESCRIPTION
💡 What: Added `title` to the iframe in privacy.astro, added `role="presentation"` to layout tables in cv.astro, and added `aria-hidden="true"` to decorative pipe characters separating links in cv.astro.

🎯 Why: Improves screen reader accessibility by providing context for the iframe, reducing unnecessary noise from layout tables, and skipping decorative text characters that are not part of the content.

📸 Before/After: Visuals remain unchanged. Screen reader experience is improved.

♿ Accessibility: WCAG 4.1.2 compliance for the iframe, improved table semantics for screen readers, and better handling of purely decorative text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the CV page’s structure and presentation for better readability and accessibility.
  * Added clearer link presentation in the CV header and marked decorative tables as presentation-only.
  * Added a title to the privacy policy embedded document for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->