### PR TITLE
⚡ Bolt: Defer Google Tag Manager initialization

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -12,17 +12,28 @@ const { title, description } = Astro.props as Props;
 <html lang="en">
     <head>
         <!-- Google Tag Manager -->
+        <!-- Optimize: Preconnect to GTM to reduce network latency -->
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
         <script is:inline>
-            (function (w, d, s, l, i) {
-                w[l] = w[l] || [];
-                w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
-                var f = d.getElementsByTagName(s)[0],
-                    j = d.createElement(s),
-                    dl = l != "dataLayer" ? "&l=" + l : "";
-                j.async = true;
-                j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
-                f.parentNode.insertBefore(j, f);
-            })(window, document, "script", "dataLayer", "GTM-55MBXTJF");
+            // Optimize: Defer GTM initialization using requestIdleCallback to improve Total Blocking Time (TBT)
+            const initGTM = () => {
+                (function (w, d, s, l, i) {
+                    w[l] = w[l] || [];
+                    w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+                    var f = d.getElementsByTagName(s)[0],
+                        j = d.createElement(s),
+                        dl = l != "dataLayer" ? "&l=" + l : "";
+                    j.async = true;
+                    j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+                    f.parentNode.insertBefore(j, f);
+                })(window, document, "script", "dataLayer", "GTM-55MBXTJF");
+            };
+
+            if ('requestIdleCallback' in window) {
+                requestIdleCallback(initGTM);
+            } else {
+                setTimeout(initGTM, 1);
+            }
         </script>
         <!-- End Google Tag Manager -->
         <meta charset="UTF-8" />


### PR DESCRIPTION
💡 What: Wrapping the Google Tag Manager inline script initialization logic in `requestIdleCallback` (with a `setTimeout` fallback) and adding a `<link rel="preconnect" href="https://www.googletagmanager.com" />` tag to the `<head>`.

🎯 Why: Inline scripts that inject third-party tags block the main thread and delay initial rendering if executed immediately. Preconnecting reduces latency and deferring non-critical execution improves Total Blocking Time (TBT).

📊 Impact: Expected to significantly reduce Total Blocking Time (TBT) and improve initial page load performance.

🔬 Measurement: Can be verified by running performance audits (e.g., Lighthouse) before and after the change, specifically observing the TBT and initial script evaluation time metrics.