### PR TITLE
🎨 Palette: Improve screen reader accessibility for layout elements

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -111,6 +111,7 @@ const { title, description } = Astro.props as Props;
         <noscript
             ><iframe
                 src="https://www.googletagmanager.com/ns.html?id=GTM-55MBXTJF"
+                title="Google Tag Manager"
                 height="0"
                 width="0"
                 style="display:none;visibility:hidden"></iframe></noscript

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -19,8 +19,8 @@ export const prerender = true;
 		
 		<p>
 			<a href="mailto:jeremygeo@gmail.com">jeremygeo@gmail.com</a>
-			 | <a href="tel:+15818491348">581-849-1348</a>
-			 | <a href="https://jeremygf.com">jeremygf.com</a>
+			 <span aria-hidden="true">|</span> <a href="tel:+15818491348">581-849-1348</a>
+			 <span aria-hidden="true">|</span> <a href="https://jeremygf.com">jeremygf.com</a>
 		</p>
 		<em>Machine Learning Engineer, Computational Biologist</em>
 		<p>
@@ -33,7 +33,7 @@ export const prerender = true;
 		<Grid items={cvData.skills} />
 		
 		<h2>Experience</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.experience.map((job) => (
 					<DatedRow row={job} />
@@ -43,7 +43,7 @@ export const prerender = true;
 
 		<h2>Projects</h2>
 
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.projects.map((project) => (
 				<Project row={project} />
@@ -52,7 +52,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Certificates</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.certificates.map((certificate) => (
 					<Project row={certificate} />
@@ -61,7 +61,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Education</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 				{cvData.education.map((school) => (
 					<DatedRow row={school} />
@@ -72,7 +72,7 @@ export const prerender = true;
 		
 
 		<h2>Publications</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.publications.map((publication) => (
 				<Publication row={publication} />
@@ -81,7 +81,7 @@ export const prerender = true;
 		</table>
 
 		<h2>Grants</h2>
-		<table>
+		<table role="presentation">
 			<tbody>
 			{cvData.grants.map((funding) => (
 				<Funding row={funding} />


### PR DESCRIPTION
💡 What
Added `role="presentation"` to layout-only `<table>` elements and explicitly hid decorative text separators (`|`) from assistive technologies using `<span aria-hidden="true">` in the CV page. Added a descriptive `title` attribute to the hidden Google Tag Manager `<iframe>` in the global layout.

🎯 Why
Layout tables confuse screen reader users because they announce table semantics (rows, columns) for content that is not tabular data. Decorative separators like `|` create unnecessary audible noise. Iframes without titles fail accessibility audits and leave screen reader users without context, even if hidden visually. These improvements create a cleaner and more focused experience for users relying on assistive technologies.

📸 Before/After
*(Visuals remain unchanged, screen reader experience improved)*

♿ Accessibility
- Prevents false data table announcements for layout grids.
- Reduces audible noise by explicitly hiding decorative characters.
- Ensures the global iframe has an accessible name, satisfying WCAG 4.1.2 Name, Role, Value.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jgeofil/personal-web/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->