### PR TITLE
⚡ Bolt: Add preconnect for Google Tag Manager

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,8 @@ const { title, description } = Astro.props as Props;
 <!doctype html>
 <html lang="en">
     <head>
+        <!-- Optimize: Added preconnect for Google Tag Manager to establish early DNS, TCP, and TLS connections before the inline script evaluates, reducing latency. -->
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
         <!-- Google Tag Manager -->
         <script is:inline>
             (function (w, d, s, l, i) {


### PR DESCRIPTION
💡 What: Added `<link rel="preconnect" href="https://www.googletagmanager.com" />` in the layout `<head>`.
🎯 Why: To establish early DNS, TCP, and TLS connections for Google Tag Manager before its inline script evaluates, which reduces latency and improves load time.
📊 Impact: Reduces Time to First Byte (TTFB) and overall resource load time for Google Tag Manager scripts.
🔬 Measurement: Verify by checking the Network tab in DevTools to ensure early connection establishment to `www.googletagmanager.com` before the script tag is parsed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jgeofil/personal-web/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->